### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/jdx/clx/compare/v1.3.0...v2.0.0) - 2026-04-16
+
+### Added
+
+- *(progress)* add ProgressOutput::Quiet variant to suppress all progress output ([#80](https://github.com/jdx/clx/pull/80))
+
+### Fixed
+
+- *(deps)* update rust crate strum to 0.28 ([#70](https://github.com/jdx/clx/pull/70))
+
+### Other
+
+- *(deps)* lock file maintenance ([#83](https://github.com/jdx/clx/pull/83))
+- *(deps)* lock file maintenance ([#82](https://github.com/jdx/clx/pull/82))
+- *(deps)* lock file maintenance ([#81](https://github.com/jdx/clx/pull/81))
+- *(deps)* lock file maintenance ([#76](https://github.com/jdx/clx/pull/76))
+- *(deps)* lock file maintenance ([#73](https://github.com/jdx/clx/pull/73))
+- *(deps)* lock file maintenance ([#72](https://github.com/jdx/clx/pull/72))
+
 ## [1.3.0](https://github.com/jdx/clx/compare/v1.2.0...v1.3.0) - 2026-01-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "1.3.0"
+version = "2.0.0"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 1.3.0 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `clx` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum ProgressOutput in /tmp/.tmpwSoe5r/clx/src/progress/output.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/jdx/clx/compare/v1.3.0...v2.0.0) - 2026-04-16

### Added

- *(progress)* add ProgressOutput::Quiet variant to suppress all progress output ([#80](https://github.com/jdx/clx/pull/80))

### Fixed

- *(deps)* update rust crate strum to 0.28 ([#70](https://github.com/jdx/clx/pull/70))

### Other

- *(deps)* lock file maintenance ([#83](https://github.com/jdx/clx/pull/83))
- *(deps)* lock file maintenance ([#82](https://github.com/jdx/clx/pull/82))
- *(deps)* lock file maintenance ([#81](https://github.com/jdx/clx/pull/81))
- *(deps)* lock file maintenance ([#76](https://github.com/jdx/clx/pull/76))
- *(deps)* lock file maintenance ([#73](https://github.com/jdx/clx/pull/73))
- *(deps)* lock file maintenance ([#72](https://github.com/jdx/clx/pull/72))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version/changelog/lockfile), with no code changes in this PR; risk is limited to publishing the intended version and metadata.
> 
> **Overview**
> Prepares the `v2.0.0` release by bumping the crate version from `1.3.0` to `2.0.0` in `Cargo.toml` and `Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the new `2.0.0` entry, noting the addition of `ProgressOutput::Quiet` and dependency/lockfile maintenance (including `strum` `0.28`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1b139c5aaef0cac37c5d91d68850744d7c42f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->