### PR TITLE
feat(progress): add ProgressOutput::Quiet variant

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -416,6 +416,9 @@ impl ProgressJob {
         if STOPPING.load(Ordering::Relaxed) {
             return;
         }
+        if output() == ProgressOutput::Quiet {
+            return;
+        }
         if output() == ProgressOutput::Text {
             let update = || {
                 let mut ctx = RenderContext {
@@ -451,7 +454,7 @@ impl ProgressJob {
     }
 
     pub fn println(&self, s: &str) {
-        if !s.is_empty() {
+        if !s.is_empty() && output() != ProgressOutput::Quiet {
             pause();
             // Safety check: ensure no flex tags are visible
             let output = if s.contains("<clx:flex>") {
@@ -587,7 +590,10 @@ pub fn flush() {
 
 fn start() {
     let mut started = STARTED.lock().unwrap();
-    if *started || output() == ProgressOutput::Text || STOPPING.load(Ordering::Relaxed) {
+    if *started
+        || matches!(output(), ProgressOutput::Text | ProgressOutput::Quiet)
+        || STOPPING.load(Ordering::Relaxed)
+    {
         return; // prevent multiple loops running at a time
     }
     // Mark as started BEFORE spawning to avoid a race that can start two loops
@@ -713,6 +719,9 @@ fn refresh() -> Result<bool> {
 }
 
 fn refresh_once() -> Result<()> {
+    if output() == ProgressOutput::Quiet {
+        return Ok(());
+    }
     let _refresh_guard = REFRESH_LOCK.lock().unwrap();
     let mut tera = TERA.lock().unwrap();
     if tera.is_none() {
@@ -1170,6 +1179,8 @@ fn add_tera_template(tera: &mut Tera, name: &str, body: &str) -> Result<()> {
 pub enum ProgressOutput {
     UI,
     Text,
+    /// Suppresses all progress output. No spinners, status lines, or text-mode updates.
+    Quiet,
 }
 
 static OUTPUT: Mutex<ProgressOutput> = Mutex::new(ProgressOutput::UI);


### PR DESCRIPTION
## Summary

- Add `ProgressOutput::Quiet` variant to suppress all progress output (spinners, status lines, text-mode updates)
- Early return in `update()`, `println()`, `refresh_once()` when Quiet
- Prevent refresh loop from spawning in Quiet mode (alongside existing Text guard)
                                                                                                                      
This enables consumers like hk and mise to fully suppress progress output for `--quiet`/`--silent` flags, rather than
falling back to `ProgressOutput::Text` which still prints text-mode status lines.
                                                                                                                      
## Test plan
- [x] `cargo test` — all 7 tests pass
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified in hk: `hk install --quiet` and `hk check --quiet` produce no progress output
                                                                                                                      
🤖 Generated with [Claude Code](https://claude.com/claude-code)
