### PR TITLE
feat(progress): add ProgressOutput::Quiet variant

### DIFF
--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -533,7 +533,7 @@ impl ProgressJob {
 
     /// Triggers a display update for this job.
     pub fn update(&self) {
-        if is_disabled() || STOPPING.load(Ordering::Relaxed) {
+        if is_disabled() || STOPPING.load(Ordering::Relaxed) || output() == ProgressOutput::Quiet {
             return;
         }
         if output() == ProgressOutput::Text {
@@ -547,7 +547,7 @@ impl ProgressJob {
 
     /// Prints a line to stderr without interfering with the progress display.
     pub fn println(&self, s: &str) {
-        if !s.is_empty() {
+        if !s.is_empty() && output() != ProgressOutput::Quiet {
             super::state::pause();
             let output = if s.contains("<clx:flex>") {
                 flex(s, term().size().1 as usize)

--- a/src/progress/output.rs
+++ b/src/progress/output.rs
@@ -8,6 +8,7 @@ use super::state::env_text_mode;
 ///
 /// Controls how progress jobs are rendered to the terminal.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[non_exhaustive]
 pub enum ProgressOutput {
     /// Rich terminal UI with animated spinners and in-place updates.
     ///
@@ -20,6 +21,11 @@ pub enum ProgressOutput {
     /// or cursor manipulation. Use this for CI systems, log files, or when stdout/stderr
     /// is not a terminal.
     Text,
+    /// Suppresses all progress output.
+    ///
+    /// No spinners, status lines, or text-mode updates are displayed.
+    /// Use this for `--quiet` or `--silent` CLI flags when only the exit code matters.
+    Quiet,
 }
 
 static OUTPUT: Mutex<ProgressOutput> = Mutex::new(ProgressOutput::UI);
@@ -44,15 +50,20 @@ pub fn set_output(output: ProgressOutput) {
 
 /// Returns the current output mode.
 ///
-/// If `CLX_TEXT_MODE=1` environment variable is set, this always returns
-/// [`ProgressOutput::Text`] regardless of what was set via [`set_output`].
+/// [`ProgressOutput::Quiet`] always takes precedence — if set, no environment
+/// variable can override it. Otherwise, if `CLX_TEXT_MODE=1` is set, this
+/// returns [`ProgressOutput::Text`] regardless of what was passed to [`set_output`].
 #[must_use]
 pub fn output() -> ProgressOutput {
-    // Environment variable takes precedence
+    let stored = *OUTPUT.lock().unwrap();
+    if stored == ProgressOutput::Quiet {
+        return ProgressOutput::Quiet;
+    }
+    // Environment variable takes precedence over UI/Text
     if env_text_mode() {
         return ProgressOutput::Text;
     }
-    *OUTPUT.lock().unwrap()
+    stored
 }
 
 #[cfg(test)]
@@ -65,6 +76,9 @@ mod tests {
 
         set_output(ProgressOutput::Text);
         assert_eq!(output(), ProgressOutput::Text);
+
+        set_output(ProgressOutput::Quiet);
+        assert_eq!(output(), ProgressOutput::Quiet);
 
         set_output(ProgressOutput::UI);
         assert_eq!(output(), ProgressOutput::UI);

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -10,6 +10,7 @@ use crate::Result;
 use super::diagnostics;
 use super::flex::flex;
 use super::job::ProgressJob;
+use super::output::{ProgressOutput, output};
 use super::state::{
     JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, TERA, TERM_LOCK,
     is_disabled, is_paused, term, update_osc_progress,
@@ -184,7 +185,7 @@ pub fn refresh() -> Result<bool> {
 
 /// Performs one refresh cycle without loop control.
 pub fn refresh_once() -> Result<()> {
-    if is_disabled() {
+    if is_disabled() || output() == ProgressOutput::Quiet {
         return Ok(());
     }
     let _refresh_guard = REFRESH_LOCK.lock().unwrap();

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -236,7 +236,7 @@ fn start() {
     let mut started = STARTED.lock().unwrap();
     if *started
         || is_disabled()
-        || output() == ProgressOutput::Text
+        || matches!(output(), ProgressOutput::Text | ProgressOutput::Quiet)
         || STOPPING.load(Ordering::Relaxed)
     {
         return;


### PR DESCRIPTION
## Summary

- Add `ProgressOutput::Quiet` variant to suppress all progress output (spinners, status lines, text-mode updates)
- Early return in `update()`, `println()`, `refresh_once()` when Quiet
- Prevent refresh loop from spawning in Quiet mode (alongside existing Text guard)
                                                                                                                      
This enables consumers like hk and mise to fully suppress progress output for `--quiet`/`--silent` flags, rather than
falling back to `ProgressOutput::Text` which still prints text-mode status lines.
                                                                                                                      
## Test plan
- [x] `cargo test` — all 7 tests pass
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified in hk: `hk install --quiet` and `hk check --quiet` produce no progress output
                                                                                                                      
🤖 Generated with [Claude Code](https://claude.com/claude-code)
