### PR TITLE
fix(progress): skip refresh_once() in Text output mode

### DIFF
--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -336,13 +336,15 @@ mod tests {
         *LINES.lock().unwrap() = 1; // simulate a previous frame
 
         let result = refresh_once();
+        let lines_after = *LINES.lock().unwrap();
 
-        assert!(result.is_ok());
-        assert_eq!(*LINES.lock().unwrap(), 1,
-            "write_frame() must not run in Text mode; LINES should be unchanged");
-
+        // Clean up before asserting so global state is always restored on panic
         *LINES.lock().unwrap() = 0;
         set_output(original);
+
+        assert!(result.is_ok());
+        assert_eq!(lines_after, 1,
+            "write_frame() must not run in Text mode; LINES should be unchanged");
     }
 
     #[test]

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -327,6 +327,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_refresh_once_skips_text_mode() {
+        use super::super::output::{ProgressOutput, output, set_output};
+        use super::super::state::LINES;
+
+        let original = output();
+        set_output(ProgressOutput::Text);
+        *LINES.lock().unwrap() = 1; // simulate a previous frame
+
+        let result = refresh_once();
+
+        assert!(result.is_ok());
+        assert_eq!(*LINES.lock().unwrap(), 1,
+            "write_frame() must not run in Text mode; LINES should be unchanged");
+
+        *LINES.lock().unwrap() = 0;
+        set_output(original);
+    }
+
+    #[test]
     fn test_indent() {
         let s = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         let result = indent(s.to_string(), 10, 2);

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -343,8 +343,10 @@ mod tests {
         set_output(original);
 
         assert!(result.is_ok());
-        assert_eq!(lines_after, 1,
-            "write_frame() must not run in Text mode; LINES should be unchanged");
+        assert_eq!(
+            lines_after, 1,
+            "write_frame() must not run in Text mode; LINES should be unchanged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
refresh_once() guarded against Quiet mode but not Text mode, so every set_status(Done/Failed/Warn/DoneCustom) call in Text mode fell through to write_frame(), emitting cursor-movement escape sequences into the log stream. GitHub Actions (PTY-backed stderr, CI=true) was capturing these as repeated full-screen redraws of the job list.

Fix: extend the early-return condition to match the identical guard already present in start() — both now skip for Text | Quiet.