### PR TITLE
fix(progress): suppress UI escape codes and duplicate lines in text mode

### DIFF
--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -445,6 +445,14 @@ impl ProgressJob {
         // Advance operation index after clearing progress values
         *self.operation_index.lock().unwrap() += 1;
 
+        // Clear the text-mode dedup cache so the first render of the new
+        // operation always reaches the wire, even if the rendered template
+        // happens to be byte-identical to the last line of the previous
+        // operation (e.g. a body that only shows `message` and message
+        // hasn't changed yet). Without this, the state-change event would
+        // be silently swallowed in CI logs.
+        *self.last_text_output.lock().unwrap() = None;
+
         self.update();
     }
 

--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -169,6 +169,7 @@ impl ProgressJobBuilder {
             operations_total: Mutex::new(None),
             operation_index: Mutex::new(0),
             operation_start: Mutex::new(Instant::now()),
+            last_text_output: Mutex::new(None),
         }
     }
 
@@ -205,6 +206,9 @@ pub struct ProgressJob {
     pub(crate) operation_index: Mutex<usize>,
     /// Start time of the current operation (for ETA calculation after next_operation)
     pub(crate) operation_start: Mutex<Instant>,
+    /// Last rendered text-mode line. Used to suppress consecutive identical
+    /// emissions when multiple props are updated in quick succession.
+    pub(crate) last_text_output: Mutex<Option<String>>,
 }
 
 impl ProgressJob {

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -184,8 +184,13 @@ pub fn refresh() -> Result<bool> {
 }
 
 /// Performs one refresh cycle without loop control.
+///
+/// In `ProgressOutput::Text` mode this is a no-op: text mode emits a fresh
+/// line for each job update, so a full-frame redraw would only repeat content
+/// already on the wire (and emit cursor-movement escape codes that look like
+/// garbage in non-TTY logs such as CI).
 pub fn refresh_once() -> Result<()> {
-    if is_disabled() || output() == ProgressOutput::Quiet {
+    if is_disabled() || matches!(output(), ProgressOutput::Quiet | ProgressOutput::Text) {
         return Ok(());
     }
     let _refresh_guard = REFRESH_LOCK.lock().unwrap();
@@ -300,6 +305,16 @@ pub fn render_text_mode(job: &ProgressJob) -> Result<()> {
         } else {
             output
         };
+        // Skip writing if this job's last text-mode line was identical. Callers
+        // often update several props in a row (e.g. `message` then `cur`); each
+        // call hits this path, but if the rendered line is unchanged there's no
+        // information to add — emitting it again just makes CI logs noisier.
+        let mut last = job.last_text_output.lock().unwrap();
+        if last.as_deref() == Some(final_output.as_str()) {
+            return Ok(());
+        }
+        *last = Some(final_output.clone());
+        drop(last);
         let _guard = TERM_LOCK.lock().unwrap();
         term().write_line(&final_output)?;
         drop(_guard);


### PR DESCRIPTION
## Summary

Two problems made `ProgressOutput::Text` output (CI logs, piped output) ugly:

1. **UI escape codes leaking into text-mode output.** `set_status(Done|Failed|Warn|DoneCustom)` and `stop()` both call `refresh_once()` to force a synchronous render. `refresh_once()` did not check the output mode, so it always took the UI path through `write_frame()` — emitting `ESC[NA`, `ESC[ND`, `ESC[0J` cursor-control sequences. In a non-TTY log they show up as raw `[9A[80D[0J` text. Now `refresh_once()` returns early in `ProgressOutput::Text`; each `update()` already streamed the relevant line, so no information is lost.

2. **Same line printed multiple times.** Updating multiple props on a single job in quick succession (e.g. `prop("message", ...)` followed immediately by an explicit `update()`, common when integrators set several fields per state transition) emitted the same rendered line repeatedly. Cache the last text-mode line per job (`last_text_output: Mutex<Option<String>>`) and skip writes that produce identical output.

Together these collapse a 30-line block of duplicates and escape codes into clean one-line-per-state-change text-mode logs. Triggered while debugging hk's CI output — see [hk#890](https://github.com/jdx/hk/pull/890) for the before/after.

## Test plan
- [x] `cargo test --lib` passes (116 tests, no regressions)
- [x] `cargo build`
- [ ] Verified end-to-end via hk patch in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-only changes scoped to progress rendering; main risk is unintentionally suppressing expected text-mode lines, mitigated by resetting the dedup cache on operation changes.
> 
> **Overview**
> Improves `ProgressOutput::Text` (non-TTY/CI) output by making `refresh_once()` a no-op in text mode, preventing full-frame redraws that emit cursor-control escape codes.
> 
> Adds per-job text-mode output deduplication by caching the last rendered line (`last_text_output`) and skipping writes when repeated updates render the same string; the cache is cleared on `next_operation()` to ensure operation transitions still emit at least one line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92c08393fc3589ecb3b9c25777b3870ffd20290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->