### PR TITLE
chore: release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/jdx/clx/compare/v2.0.0...v2.0.1) - 2026-04-30
+
+### Fixed
+
+- *(progress)* suppress UI escape codes and duplicate lines in text mode ([#86](https://github.com/jdx/clx/pull/86))
+
 ## [2.0.0](https://github.com/jdx/clx/compare/v1.3.0...v2.0.0) - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.1](https://github.com/jdx/clx/compare/v2.0.0...v2.0.1) - 2026-04-30

### Fixed

- *(progress)* suppress UI escape codes and duplicate lines in text mode ([#86](https://github.com/jdx/clx/pull/86))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: bumps the crate version and updates the changelog/lockfile without touching runtime code paths.
> 
> **Overview**
> Cuts release `v2.0.1` by bumping the crate version in `Cargo.toml`/`Cargo.lock` and adding a `2.0.1` entry to `CHANGELOG.md` noting a progress text-mode fix (escape codes/duplicate lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 322354b76e455d03e247d0e75ec65c540e58ae47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->