### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,6 @@ test-log = "0.2"
 [[example]]
 name = "log_integration"
 required-features = ["log"]
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Cargo build profile settings; behavior should be unchanged aside from reduced debug symbol detail in dev builds.
> 
> **Overview**
> Sets Cargo’s dev build profile to `debug = 1` in `Cargo.toml` to reduce generated debug info (and typically `target/` size) for local builds, while keeping basic file:line backtraces available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a48b47b418db5576e9dcaf4021664af4361e5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->