### PR TITLE
chore: release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/jdx/clx/compare/v2.0.1...v2.0.2) - 2026-05-03
+
+### Other
+
+- set dev profile debug to 1 ([#89](https://github.com/jdx/clx/pull/89))
+
 ## [2.0.1](https://github.com/jdx/clx/compare/v2.0.0...v2.0.1) - 2026-04-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.0.1 -> 2.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.2](https://github.com/jdx/clx/compare/v2.0.1...v2.0.2) - 2026-05-03

### Other

- set dev profile debug to 1 ([#89](https://github.com/jdx/clx/pull/89))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: bumps crate version to `2.0.2` and updates the changelog/lockfile without touching runtime logic.
> 
> **Overview**
> Publishes release `v2.0.2` by bumping the crate version in `Cargo.toml`/`Cargo.lock` and adding the corresponding `CHANGELOG.md` entry (noting `dev` profile debug set to `1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acaae67e1fdb2074325ea08c73ce0f9a32ee1f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->