### PR TITLE
fix(progress): update Tera template when body changes

### DIFF
--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -170,6 +170,7 @@ impl ProgressJobBuilder {
             operation_index: Mutex::new(0),
             operation_start: Mutex::new(Instant::now()),
             last_text_output: Mutex::new(None),
+            last_compiled_body: Mutex::new(None),
         }
     }
 
@@ -209,6 +210,9 @@ pub struct ProgressJob {
     /// Last rendered text-mode line. Used to suppress consecutive identical
     /// emissions when multiple props are updated in quick succession.
     pub(crate) last_text_output: Mutex<Option<String>>,
+    /// Last compiled Tera template body. Used to skip recompiling when the
+    /// body has not changed since the last render frame.
+    pub(crate) last_compiled_body: Mutex<Option<String>>,
 }
 
 impl ProgressJob {
@@ -236,7 +240,13 @@ impl ProgressJob {
             self.body.lock().unwrap().clone()
         };
         let name = format!("progress_{}", self.id);
-        add_tera_template(tera, &name, &body)?;
+        {
+            let mut last = self.last_compiled_body.lock().unwrap();
+            if last.as_deref() != Some(&body) {
+                add_tera_template(tera, &name, &body)?;
+                *last = Some(body.clone());
+            }
+        }
         let rendered_body = tera.render(&name, &ctx.tera_ctx)?;
         let flex_width = ctx.width.saturating_sub(ctx.indent);
         let body = flex(&rendered_body, flex_width);

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -277,11 +277,9 @@ pub fn indent(s: String, width: usize, indent_size: usize) -> String {
     result.join("\n")
 }
 
-/// Adds a raw template to the Tera engine if it doesn't already exist.
+/// Adds a raw template to the Tera engine, updating it if it already exists.
 pub fn add_tera_template(tera: &mut Tera, name: &str, body: &str) -> Result<()> {
-    if !tera.get_template_names().any(|n| n == name) {
-        tera.add_raw_template(name, body)?;
-    }
+    tera.add_raw_template(name, body)?;
     Ok(())
 }
 


### PR DESCRIPTION
The add_tera_template function previously only added a template if it did not already exist. This meant that set_body() calls on a ProgressJob would update the body string but the Tera template cache would not be updated, so the rendered output would still use the old template.

This change always updates the Tera template, so set_body() now works correctly when called after the job has been started.