### PR TITLE
chore: release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3](https://github.com/jdx/clx/compare/v2.0.2...v2.0.3) - 2026-05-10
+
+### Fixed
+
+- *(progress)* update Tera template when body changes ([#92](https://github.com/jdx/clx/pull/92))
+
 ## [2.0.2](https://github.com/jdx/clx/compare/v2.0.1...v2.0.2) - 2026-05-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.0.2 -> 2.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.3](https://github.com/jdx/clx/compare/v2.0.2...v2.0.3) - 2026-05-10

### Fixed

- *(progress)* update Tera template when body changes ([#92](https://github.com/jdx/clx/pull/92))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog entry updates, with no functional code changes in this diff.
> 
> **Overview**
> Bumps `clx` version from `2.0.2` to `2.0.3` in `Cargo.toml` and `Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `2.0.3` release entry noting a progress-related fix (Tera template refresh when the body changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe2ca24df36a022f6d893a0416926bc3dbdd465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->