### PR TITLE
feat(progress): add clear_jobs() to remove all top-level jobs

### DIFF
--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -342,8 +342,8 @@ mod log;
 pub use job::{ProgressJob, ProgressJobBuilder, ProgressJobDoneBehavior, ProgressStatus};
 pub use output::{ProgressOutput, output, set_output};
 pub use state::{
-    active_jobs, flush, interval, is_disabled, is_paused, job_count, pause, resume, set_interval,
-    stop, stop_clear, with_terminal_lock,
+    active_jobs, clear_jobs, flush, interval, is_disabled, is_paused, job_count, pause, resume,
+    set_interval, stop, stop_clear, with_terminal_lock,
 };
 
 #[cfg(feature = "log")]
@@ -858,5 +858,20 @@ mod tests {
 
         job.remove();
         assert_eq!(job_count(), initial_count);
+    }
+
+    #[test]
+    fn test_clear_jobs() {
+        let _j1 = ProgressJobBuilder::new().prop("message", "a").start();
+        let _j2 = ProgressJobBuilder::new().prop("message", "b").start();
+        assert!(job_count() >= 2);
+
+        clear_jobs();
+        assert_eq!(job_count(), 0);
+
+        // A subsequent job starts fresh
+        let _j3 = ProgressJobBuilder::new().prop("message", "c").start();
+        assert_eq!(job_count(), 1);
+        clear_jobs();
     }
 }

--- a/src/progress/mod.rs
+++ b/src/progress/mod.rs
@@ -874,4 +874,20 @@ mod tests {
         assert_eq!(job_count(), 1);
         clear_jobs();
     }
+
+    #[test]
+    fn test_clear_jobs_rearms_rendering_after_stop() {
+        use std::sync::atomic::Ordering;
+        // Drive into the "stopped" state and confirm STOPPING is latched.
+        let job = ProgressJobBuilder::new().prop("message", "a").start();
+        job.set_status(ProgressStatus::Done);
+        stop();
+        assert!(state::STOPPING.load(Ordering::Relaxed));
+
+        // clear_jobs must both drop registered jobs and reset STOPPING so a
+        // subsequent session can actually drive updates again.
+        clear_jobs();
+        assert_eq!(job_count(), 0);
+        assert!(!state::STOPPING.load(Ordering::Relaxed));
+    }
 }

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -321,6 +321,19 @@ pub fn active_jobs() -> usize {
     count_active(&JOBS.lock().unwrap())
 }
 
+/// Removes all top-level progress jobs from the registry.
+///
+/// Useful after [`stop`] or [`stop_clear`] when you're starting a fresh
+/// session: those functions stop rendering and (for `stop_clear`) clear the
+/// display, but they leave completed jobs registered. A later call to add
+/// a new job would otherwise re-render the stale jobs alongside the new one.
+///
+/// This does not affect the terminal display — call [`stop_clear`] first if
+/// you also want to clear the rendered output.
+pub fn clear_jobs() {
+    JOBS.lock().unwrap().clear();
+}
+
 // =============================================================================
 // Clear Display
 // =============================================================================

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -321,17 +321,27 @@ pub fn active_jobs() -> usize {
     count_active(&JOBS.lock().unwrap())
 }
 
-/// Removes all top-level progress jobs from the registry.
+/// Removes all top-level progress jobs from the registry and re-enables
+/// rendering after [`stop`] / [`stop_clear`].
 ///
-/// Useful after [`stop`] or [`stop_clear`] when you're starting a fresh
-/// session: those functions stop rendering and (for `stop_clear`) clear the
-/// display, but they leave completed jobs registered. A later call to add
-/// a new job would otherwise re-render the stale jobs alongside the new one.
+/// `stop` and `stop_clear` set the internal `STOPPING` flag, which makes
+/// subsequent `update()` calls (and the background thread) no-op forever.
+/// On its own this would mean a new job added after `stop` doesn't animate
+/// — only its final terminal-state flush would render. `clear_jobs` resets
+/// `STOPPING` alongside dropping the registered jobs so the documented
+/// "start a fresh session" workflow actually works:
 ///
-/// This does not affect the terminal display — call [`stop_clear`] first if
+/// ```ignore
+/// progress::stop();        // end session, jobs stay registered
+/// progress::clear_jobs();  // drop them and re-arm rendering
+/// let job = ProgressJobBuilder::new().start(); // new session renders normally
+/// ```
+///
+/// This does not touch the terminal display — call [`stop_clear`] first if
 /// you also want to clear the rendered output.
 pub fn clear_jobs() {
     JOBS.lock().unwrap().clear();
+    STOPPING.store(false, Ordering::Relaxed);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`stop()` and `stop_clear()` end the rendering session — they stop the background thread, render/clear the display, and reset `LINES` — but they leave the completed jobs registered in the global `JOBS` `Vec`. With the default `ProgressJobDoneBehavior::Keep`, a caller that starts a fresh session by adding a new job after `stop` will see the next refresh re-render every previously-completed job alongside the new ones.

This bit mise in [jdx/mise#9774](https://github.com/jdx/mise/discussions/9774): `mise upgrade` finishes installing (calls `stop()`), then adds an "uninstall" progress job, and the installed-tools block gets printed twice.

Adding `clear_jobs()` lets callers explicitly drop the registered jobs after stopping, without needing to hold `Arc<ProgressJob>` references to each.

## What's not changing

- `stop()`/`stop_clear()` semantics — narrow contract preserved
- `job_count()` / `active_jobs()` — continue to reflect what's currently registered, including completed-but-still-displayed jobs

`clear_jobs()` is purely additive. mise (and any other caller that wants the old behavior) can opt in.

## Test plan
- [x] `cargo build`
- [x] `cargo test -- --test-threads=1` (117 passing, including new `test_clear_jobs`)
- [x] `cargo clippy` (no new warnings)
- [x] `cargo fmt --check`

Follow-up: [jdx/mise#9779](https://github.com/jdx/mise/pull/9779) currently has a mise-side workaround tracking jobs in a Vec; once this lands and clx is released, the mise PR will be simplified to call `progress::clear_jobs()` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies global progress lifecycle state by clearing `JOBS` and resetting the `STOPPING` latch, which could affect rendering/thread behavior across sessions if misused.
> 
> **Overview**
> Adds a new public `clear_jobs()` API to explicitly drop all registered top-level progress jobs and reset the internal stopped state, allowing a new progress “session” to render/animate normally after `stop()`/`stop_clear()`.
> 
> Includes new unit tests covering registry clearing behavior and verifying that `clear_jobs()` resets the `STOPPING` flag so subsequent jobs refresh correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bec5e365717e028a81bfd1f5f85dc1fce4440fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->