### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/jdx/clx/compare/v2.0.3...v2.1.0) - 2026-05-11
+
+### Added
+
+- *(progress)* add clear_jobs() to remove all top-level jobs ([#94](https://github.com/jdx/clx/pull/94))
+
 ## [2.0.3](https://github.com/jdx/clx/compare/v2.0.2...v2.0.3) - 2026-05-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.0.3"
+version = "2.1.0"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.0.3"
+version = "2.1.0"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.0.3 -> 2.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.0](https://github.com/jdx/clx/compare/v2.0.3...v2.1.0) - 2026-05-11

### Added

- *(progress)* add clear_jobs() to remove all top-level jobs ([#94](https://github.com/jdx/clx/pull/94))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release bookkeeping only: version bumps and changelog update, with no functional code changes in this PR.
> 
> **Overview**
> Prepares the **v2.1.0** release by bumping the crate version in `Cargo.toml`/`Cargo.lock` and adding a new `CHANGELOG.md` entry for 2.1.0 (noting the `progress` addition of `clear_jobs()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25cf821dd8deffd04a55555f9cd409f6be98cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->