### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/jdx/clx/compare/v2.1.0...v2.1.1) - 2026-05-17
+
+### Fixed
+
+- *(progress)* prevent frame duplication in println() ([#96](https://github.com/jdx/clx/pull/96))
+
 ## [2.1.0](https://github.com/jdx/clx/compare/v2.0.3...v2.1.0) - 2026-05-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/jdx/clx/compare/v2.1.0...v2.1.1) - 2026-07-24
+
+### Fixed
+
+- *(progress)* wrap in-place redraws in synchronized updates ([#101](https://github.com/jdx/clx/pull/101))
+- *(progress)* prevent frame duplication in println() ([#96](https://github.com/jdx/clx/pull/96))
+
+### Other
+
+- *(deps)* lock file maintenance ([#91](https://github.com/jdx/clx/pull/91))
+- raise MSRV to Rust 1.88 ([#99](https://github.com/jdx/clx/pull/99))
+
 ## [2.1.0](https://github.com/jdx/clx/compare/v2.0.3...v2.1.0) - 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "console",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "clx"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.1.0 -> 2.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.1](https://github.com/jdx/clx/compare/v2.1.0...v2.1.1) - 2026-07-24

### Fixed

- *(progress)* wrap in-place redraws in synchronized updates ([#101](https://github.com/jdx/clx/pull/101))
- *(progress)* prevent frame duplication in println() ([#96](https://github.com/jdx/clx/pull/96))

### Other

- *(deps)* lock file maintenance ([#91](https://github.com/jdx/clx/pull/91))
- raise MSRV to Rust 1.88 ([#99](https://github.com/jdx/clx/pull/99))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/lockfile metadata only; no runtime code changes in this diff.
> 
> **Overview**
> **Release v2.1.1** — bumps the `clx` crate from **2.1.0** to **2.1.1** in `Cargo.toml` and `Cargo.lock`, and adds the **2.1.1** section to `CHANGELOG.md`.
> 
> This PR does not change library source; it packages already-merged work: progress fixes (synchronized in-place redraws, `println()` frame duplication), dependency lockfile maintenance, and **MSRV raised to Rust 1.88** (already reflected in `Cargo.toml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c13dbefb578793a2feac369b1d248ce4c4d578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->