### PR TITLE
chore: raise MSRV to Rust 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/jdx/clx"
 readme = "README.md"
 include = ["examples/**/*.rs", "src/**/*.rs"]
-rust-version = "1.85"
+rust-version = "1.88"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- raise the declared MSRV from Rust 1.85 to Rust 1.88
- allow clx's dependency graph to adopt crates that use let chains stabilized in Rust 1.88
- align the support floor with current clx consumers

## Validation

- `cargo +1.88.0 test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata change with no runtime or API impact; only affects which Rust toolchains can build the crate.
> 
> **Overview**
> Raises the crate’s **minimum supported Rust version** from **1.85** to **1.88** via the `rust-version` field in `Cargo.toml`.
> 
> This is a policy/support-floor change only: no application source or dependency version bumps in the diff. The intent is to match consumers and to allow dependency updates that rely on **let chains** (stable in 1.88).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c82cf610c3896f6872e3e2c4611d6451e0b9354a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->