### PR TITLE
chore(ci): add final status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,43 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
       - run: mise x -- cargo msrv verify
+
+  # Aggregator that required-status-checks can target. If any upstream job
+  # failed or was skipped, this job fails so branch protection only needs one
+  # stable check name.
+  final:
+    needs:
+      - ci
+      - msrv
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
+    steps:
+      - name: Gate on upstream job results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = False
+          for name, data in sorted(needs.items()):
+              result = data.get("result", "unknown")
+              if result == "success":
+                  print(f"::notice::{name}: {result}")
+              else:
+                  print(f"::error::{name}: {result}")
+                  failed = True
+
+          if failed:
+              print("One or more upstream jobs did not complete successfully.")
+              sys.exit(1)
+
+          print("All CI jobs completed successfully.")
+          PY


### PR DESCRIPTION
## Summary

- add a `final` CI aggregation job that depends on the `ci` matrix and `msrv` jobs
- fail the aggregate check when any upstream job fails or is skipped
- skip the aggregate runner when the workflow is cancelled so `cancel-in-progress` remains effective
- provide one stable check name for branch protection

## Validation

- `actionlint .github/workflows/ci.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no runtime or application code impact; behavior is limited to how CI status is reported for merges.
> 
> **Overview**
> Adds a **`final`** job to the CI workflow that depends on the **`ci`** matrix and **`msrv`** jobs, giving branch protection a single stable required check instead of listing every matrix leg.
> 
> The job runs when the workflow is not cancelled (`!cancelled()`), avoiding the extra runner use that `always()` would cause under `cancel-in-progress`. A small **Python** step reads `needs` via `toJSON(needs)`, fails if any upstream job is not `success` (including skipped), and emits GitHub Actions notices/errors per job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f3944026528be6e2115958116d53b8a08442120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->