### PR TITLE
fix(progress): wrap in-place redraws in synchronized updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,10 +71,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -113,6 +125,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -159,13 +177,14 @@ version = "2.1.0"
 dependencies = [
  "console",
  "log",
- "nix",
+ "nix 0.31.3",
+ "portable-pty",
  "serde",
  "serde_json",
  "strum",
  "tera",
  "test-log",
- "thiserror",
+ "thiserror 2.0.19",
  "unicode-width",
 ]
 
@@ -225,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +275,17 @@ dependencies = [
  "anstyle",
  "env_filter",
  "log",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -312,7 +348,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "ignore",
  "walkdir",
 ]
@@ -436,13 +472,25 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -576,6 +624,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -722,6 +791,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +809,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -857,11 +953,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1030,6 +1146,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1169,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1104,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ nix = { version = "0.31", features = ["signal", "user"] }
 [dev-dependencies]
 test-log = "0.2"
 
+[target.'cfg(unix)'.dev-dependencies]
+portable-pty = "0.9.0"
+
 [[example]]
 name = "log_integration"
 required-features = ["log"]

--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -15,7 +15,7 @@ use super::output::{ProgressOutput, output};
 use super::render::{RenderContext, add_tera_template, indent, render_text_mode};
 use super::spinners::DEFAULT_BODY;
 use super::state::{
-    JOBS, LAST_OUTPUT, REFRESH_LOCK, STOPPING, TERM_LOCK, is_disabled, notify, term,
+    JOBS, LAST_OUTPUT, REFRESH_LOCK, STOPPING, SyncUpdate, TERM_LOCK, is_disabled, notify, term,
 };
 use super::tera_setup::add_tera_functions;
 
@@ -592,6 +592,7 @@ impl ProgressJob {
         // redraw the frame below it.  Hold REFRESH_LOCK throughout so the
         // background render thread cannot interleave a write_frame().
         let _refresh_guard = REFRESH_LOCK.lock().unwrap();
+        let _sync = SyncUpdate::begin_locking();
 
         super::state::pause();
         {

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -12,8 +12,8 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, TERA, TERM_LOCK,
-    is_disabled, is_paused, term, update_osc_progress,
+    JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate, TERA,
+    TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
 
 /// Context for rendering a frame.
@@ -105,6 +105,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
     let mut lines = LINES.lock().unwrap();
 
     let _guard = TERM_LOCK.lock().unwrap();
+    let _sync = SyncUpdate::begin();
 
     // Clear previous frame
     if *lines > 0 {

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -5,7 +5,7 @@
 //! refresh thread.
 
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex, OnceLock, mpsc};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -57,6 +57,68 @@ pub(crate) static LINES: Mutex<usize> = Mutex::new(0);
 
 /// Global terminal lock for synchronizing output operations.
 pub static TERM_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// DEC private mode 2026 (synchronized output). A terminal that implements the
+/// mode buffers everything between these and presents it as one frame. One that
+/// does not ignores the unknown private mode. We emit unconditionally rather
+/// than probing for support, matching Homebrew/brew#23264.
+const BEGIN_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026h";
+const END_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026l";
+
+/// Nesting depth of open synchronized updates. Mode 2026 is a set/reset flag,
+/// not a counter, so a nested reset would end the outer update early: only the
+/// outermost guard emits. Mutated only while `TERM_LOCK` is held.
+static SYNC_DEPTH: AtomicUsize = AtomicUsize::new(0);
+
+fn emit_synchronized_updates() -> bool {
+    !is_disabled() && output() == ProgressOutput::UI
+}
+
+/// RAII guard that brackets an in-place redraw in a synchronized update so a
+/// fast terminal cannot present a half-drawn frame between the individual
+/// cursor-movement and write operations.
+#[must_use = "the update ends when this guard drops, so it must be bound for the redraw it protects"]
+pub(crate) struct SyncUpdate {
+    locks: bool,
+    emitted_begin: bool,
+}
+
+impl SyncUpdate {
+    /// Begins a synchronized update for a caller that already holds `TERM_LOCK`.
+    pub(crate) fn begin() -> Self {
+        Self::enter(false)
+    }
+
+    /// Begins a synchronized update, briefly taking `TERM_LOCK` around each
+    /// emission for a caller that does not already hold it (e.g. a span across
+    /// several separately-locked writes).
+    pub(crate) fn begin_locking() -> Self {
+        Self::enter(true)
+    }
+
+    fn enter(locks: bool) -> Self {
+        let _guard = locks.then(|| TERM_LOCK.lock().unwrap());
+        let is_outermost = SYNC_DEPTH.fetch_add(1, Ordering::SeqCst) == 0;
+        let emitted_begin = is_outermost && emit_synchronized_updates();
+        if emitted_begin {
+            let _ = term().write_str(BEGIN_SYNCHRONIZED_UPDATE);
+        }
+        Self {
+            locks,
+            emitted_begin,
+        }
+    }
+}
+
+impl Drop for SyncUpdate {
+    fn drop(&mut self) {
+        let _guard = self.locks.then(|| TERM_LOCK.lock().unwrap());
+        SYNC_DEPTH.fetch_sub(1, Ordering::SeqCst);
+        if self.emitted_begin {
+            let _ = term().write_str(END_SYNCHRONIZED_UPDATE);
+        }
+    }
+}
 
 /// Lock to ensure only one refresh cycle runs at a time.
 pub(crate) static REFRESH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
@@ -354,9 +416,11 @@ pub(crate) fn clear() -> crate::Result<()> {
     let mut lines = LINES.lock().unwrap();
     if *lines > 0 {
         let _guard = TERM_LOCK.lock().unwrap();
+        let _sync = SyncUpdate::begin();
         term.move_cursor_up(*lines)?;
         term.move_cursor_left(term.size().1 as usize)?;
         term.clear_to_end_of_screen()?;
+        drop(_sync);
         drop(_guard);
     }
     *lines = 0;

--- a/tests/synchronized_output.rs
+++ b/tests/synchronized_output.rs
@@ -1,0 +1,143 @@
+//! Verifies that in-place redraws are wrapped in DEC mode 2026 synchronized
+//! updates so a fast terminal cannot present a half-drawn frame.
+//!
+//! `write_frame` never runs in the crate's other tests, which all use text
+//! mode. Driving the real UI-mode render path requires a tty, so the parent
+//! test spawns this same binary under a pseudo-terminal, runs a scenario in
+//! the child, and inspects the raw byte stream the child wrote.
+//!
+//! Unix only. The guard itself is platform-independent, but this test reads
+//! the escape bytes back off a pty, and ConPTY does not fit that: its master
+//! does not reliably signal EOF when the child exits, and it parses and
+//! re-emits the stream rather than passing sequences through verbatim.
+#![cfg(unix)]
+
+use std::io::Read;
+use std::time::Duration;
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+const BEGIN: &[u8] = b"\x1b[?2026h";
+
+/// Child entry point. A no-op during a normal `cargo test` run; the parent
+/// re-invokes it with `CLX_PTY_SCENARIO=1` under a pty to produce real frames.
+#[test]
+fn synchronized_output_child_scenario() {
+    if std::env::var_os("CLX_PTY_SCENARIO").is_none() {
+        return;
+    }
+
+    use clx::progress::{ProgressJobBuilder, ProgressStatus};
+
+    let root = ProgressJobBuilder::new().prop("message", "root").start();
+    let child = ProgressJobBuilder::new().prop("message", "child").start();
+    for i in 0..5 {
+        std::thread::sleep(Duration::from_millis(60));
+        child.prop("message", &format!("step {i}"));
+        root.println(&format!("log line {i}"));
+    }
+    std::thread::sleep(Duration::from_millis(120));
+    child.set_status(ProgressStatus::Done);
+    root.set_status(ProgressStatus::Done);
+    clx::progress::stop();
+
+    std::process::exit(0);
+}
+
+#[test]
+fn every_redraw_is_wrapped_in_a_synchronized_update() {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(std::env::current_exe().expect("current_exe"));
+    cmd.args([
+        "--exact",
+        "synchronized_output_child_scenario",
+        "--nocapture",
+    ]);
+    cmd.env("CLX_PTY_SCENARIO", "1");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn child");
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes).expect("read pty");
+    child.wait().expect("wait child");
+    drop(pair.master);
+
+    assert!(
+        contains(&bytes, BEGIN),
+        "scenario emitted no synchronized-update sequences; the render path did not run"
+    );
+
+    let mut open = false;
+    for op in escapes(&bytes) {
+        match op {
+            Escape::Begin => {
+                assert!(
+                    !open,
+                    "nested synchronized update: a second begin with no end"
+                );
+                open = true;
+            }
+            Escape::End => {
+                assert!(open, "synchronized-update end with no matching begin");
+                open = false;
+            }
+            Escape::Erase => assert!(
+                open,
+                "in-place redraw (cursor-up or clear-to-end-of-screen) outside a synchronized update"
+            ),
+        }
+    }
+    assert!(!open, "stream ended with a synchronized update left open");
+}
+
+enum Escape {
+    Begin,
+    End,
+    Erase,
+}
+
+/// Yields the redraw-relevant CSI sequences in order: the mode-2026 begin/end
+/// pair and the erase operations (cursor-up `ESC[<n>A`, clear-to-end `ESC[0J`).
+/// Every other byte, including OSC sequences and the frame text, is ignored.
+fn escapes(bytes: &[u8]) -> Vec<Escape> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != 0x1b || bytes.get(i + 1) != Some(&b'[') {
+            i += 1;
+            continue;
+        }
+        let params_start = i + 2;
+        let mut j = params_start;
+        while j < bytes.len() && !(0x40..=0x7e).contains(&bytes[j]) {
+            j += 1;
+        }
+        if j >= bytes.len() {
+            break;
+        }
+        let final_byte = bytes[j];
+        let params = &bytes[params_start..j];
+        match final_byte {
+            b'h' if params == b"?2026" => out.push(Escape::Begin),
+            b'l' if params == b"?2026" => out.push(Escape::End),
+            b'A' | b'J' => out.push(Escape::Erase),
+            _ => {}
+        }
+        i = j + 1;
+    }
+    out
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}


### PR DESCRIPTION
Fixes an issue where output flickers in fast-rendering Terminal emulators such as Ghostty. See screen recording below.

## Problem

Every redraw erases the previous frame and writes the new one. clx renders through `console::Term`, which is unbuffered, so each step is its own write and flush. `write_frame` issues four of them: cursor-up, cursor-left, clear-to-end-of-screen, then the frame text. A fast terminal can present between them, showing a blank or half-drawn frame.

I fixed the same class of bug in Homebrew in [brew#23264](https://github.com/Homebrew/brew/pull/23264).

Three paths produce it, in rough order of how often they fire under mise:

- **The background refresh loop.** A live spinner defeats the smart-skip in `refresh`, so every cycle erases and rewrites the whole block for the duration of an install.
- **`ProgressJob::println`.** mise routes every subprocess stderr line here, unthrottled, at pipe speed during builds. The sequence is `pause()` → `clear()`, the log line, `resume()`, then a render and `write_frame`. That is roughly eight writes with two presentable intermediate states.
- **The final `stop()` frame**, once per run.

## Screencasts

### Before


https://github.com/user-attachments/assets/b4cfcc50-8ec0-44be-a3f1-1e49fd9c545c



### After


https://github.com/user-attachments/assets/15334015-3308-47d1-9d7a-b7f88fd5a407



## Fix

Bracket each in-place redraw in DEC private mode 2026 (synchronized output). The terminal buffers everything between `ESC[?2026h` and `ESC[?2026l` and presents it as a single frame.

`SyncUpdate` in `src/progress/state.rs` is an RAII guard applied at three sites:

- `write_frame` in `src/progress/render.rs`
- `clear` in `src/progress/state.rs`
- the TTY branch of `ProgressJob::println` in `src/progress/job.rs`, spanning the whole pause-print-redraw sequence so it presents once

Mode 2026 is a set/reset flag rather than a counter, so a nested reset would end the outer update early. The guard tracks depth and only the outermost pair is emitted. The `println` span nests the `clear` and `write_frame` guards inside it.

Emission is unconditional. Terminals that do not implement the mode ignore the unknown private mode, so there is no capability probe. It is gated on `ProgressOutput::UI`, which leaves text mode byte-for-byte unchanged and keeps escape noise out of CI logs.

No new runtime dependency.

## Testing

`tests/synchronized_output.rs` spawns the test binary under a pty and asserts that every cursor-up and clear-to-end-of-screen occurs inside a balanced, closed synchronized update. The crate's other tests all run in text mode, where `write_frame` never executes, so a pty is what makes this path observable at all.

The test is Unix only, along with the `portable-pty` dev-dependency. ConPTY does not fit it: its master does not reliably signal EOF when the child exits, which hangs the read, and it parses and re-emits the stream rather than passing sequences through verbatim, so the byte-level assertions would not mean anything there. The guard itself is platform-independent, so this narrows where the behavior is observed rather than where it holds.

Over an identical workload, the pre-fix build emits zero synchronized-update sequences and the post-fix build emits 417 begin/end pairs, all balanced.

Checked in Ghostty, which implements the mode, and Apple Terminal, which does not.

## Out of Scope

mise's logger calls `progress::pause()`, `eprintln!`, then `progress::resume()`. `resume()` only notifies the render thread, which sleeps up to half the refresh interval before redrawing, so the progress block is absent for 0-100ms after every warn or info line. That is wall-clock separation between two frames rather than a torn write, so no bracket can span it. The redraw happens on another thread after `resume()` returns. Closing it needs either a synchronous redraw or a scoped `with_paused` API.

Separately, on SIGWINCH the loop re-renders, but `write_frame` erases using the line count computed at the old width, so narrowing a window mid-run leaves residue rows. That is persistent corruption rather than a flash, and mode 2026 does not affect it.

