### PR TITLE
chore: release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/jdx/clx/compare/v2.1.1...v3.0.0) - 2026-07-24
+
+### Fixed
+
+- *(deps)* [**breaking**] update rust crate tera to v2 ([#106](https://github.com/jdx/clx/pull/106))
+
 ## [2.1.1](https://github.com/jdx/clx/compare/v2.1.0...v2.1.1) - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clx"
-version = "2.1.1"
+version = "3.0.0"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "2.1.1"
+version = "3.0.0"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 2.1.1 -> 3.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.0](https://github.com/jdx/clx/compare/v2.1.1...v3.0.0) - 2026-07-24

### Fixed

- *(deps)* [**breaking**] update rust crate tera to v2 ([#106](https://github.com/jdx/clx/pull/106))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump with no runtime code changes in this PR; consumers should treat 3.0.0 as a major release due to the Tera v2 dependency noted in the changelog.
> 
> **Overview**
> **Release v3.0.0** bumps the `clx` crate from **2.1.1** to **3.0.0** in `Cargo.toml` and `Cargo.lock`, and adds the corresponding **3.0.0** section to `CHANGELOG.md`.
> 
> The release is driven by a **breaking** dependency change already merged: **Tera** was upgraded to **v2** (see [#106](https://github.com/jdx/clx/pull/106)), which is why the semver major bump. No application source changes appear in this diff—only version and changelog metadata from **release-plz**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3355ec5365a429bdb2fa6941b91f2f3c6f301bb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->