### PR TITLE
fix(progress): clear reflowed frame after resize

### DIFF
--- a/examples/resize.rs
+++ b/examples/resize.rs
@@ -1,0 +1,54 @@
+//! Long-running terminal resize demo.
+//!
+//! Run with: cargo run --example resize
+
+use std::{thread, time::Duration};
+
+use clx::progress::{ProgressJobBuilder, ProgressJobDoneBehavior, ProgressStatus, set_interval};
+
+const MESSAGES: [&str; 6] = [
+    "fetching package metadata from the configured registry",
+    "resolving a deliberately long dependency description",
+    "downloading an archive with enough text to wrap when narrow",
+    "verifying checksums and artifact provenance",
+    "linking executables into the destination directory",
+    "updating the final lockfile and installation manifest",
+];
+
+fn main() {
+    eprintln!("Resize this terminal freely; the demo runs for about 20 seconds.");
+
+    set_interval(Duration::from_millis(50));
+    let root = ProgressJobBuilder::new()
+        .body("{{ spinner() }} resize demo  {{ progress_bar(flex=true) }}  {{ cur }}/{{ total }}")
+        .body_text(Some("resize demo {{ cur }}/{{ total }}"))
+        .progress_total(400)
+        .progress_current(0)
+        .on_done(ProgressJobDoneBehavior::Collapse)
+        .start();
+
+    let children = MESSAGES
+        .iter()
+        .map(|message| {
+            root.add(
+                ProgressJobBuilder::new()
+                    .prop("message", message)
+                    .on_done(ProgressJobDoneBehavior::Collapse)
+                    .build(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    for tick in 0..=400 {
+        root.progress_current(tick);
+        let child = tick % children.len();
+        children[child].prop("message", &format!("{} · item {tick:03}", MESSAGES[child]));
+        thread::sleep(Duration::from_millis(50));
+    }
+
+    for child in children {
+        child.set_status(ProgressStatus::Done);
+    }
+    root.set_status(ProgressStatus::Done);
+    clx::progress::stop();
+}

--- a/src/progress/job.rs
+++ b/src/progress/job.rs
@@ -612,8 +612,13 @@ impl ProgressJob {
         // If rendering fails the log line is already on screen — best-effort redraw.
         if let Ok(frame) = super::render::render_frame() {
             let final_output = super::render::process_flex_output(&frame.output);
-            *LAST_OUTPUT.lock().unwrap() = final_output.clone();
-            let _ = super::render::write_frame(&final_output, &frame.jobs);
+            if let Ok(written) = super::render::write_frame(&final_output, &frame.jobs) {
+                super::render::cache_written_output(
+                    &mut LAST_OUTPUT.lock().unwrap(),
+                    &final_output,
+                    written,
+                );
+            }
         }
     }
 }

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -198,7 +198,8 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     // SIGWINCH. Reset the visible viewport once, then suppress output until a
     // complete frame fits again. Terminal states still get a best-effort final
     // render.
-    if any_running && output_height.max(previous_height) >= term_height {
+    if any_running && frame_fills_viewport(output_height, previous_height, *lines > 0, term_height)
+    {
         let first_cramped = !CRAMPED_VIEWPORT.swap(true, std::sync::atomic::Ordering::Relaxed);
         if *lines > 0 && first_cramped {
             let _sync = SyncUpdate::begin();
@@ -252,6 +253,16 @@ pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
             }
         })
         .sum()
+}
+
+fn frame_fills_viewport(
+    output_height: usize,
+    previous_height: usize,
+    previous_visible: bool,
+    term_height: usize,
+) -> bool {
+    let visible_previous_height = if previous_visible { previous_height } else { 0 };
+    output_height.max(visible_previous_height) >= term_height
 }
 
 pub(crate) fn cache_written_output(last_output: &mut String, output: &str, written: bool) {
@@ -494,6 +505,13 @@ mod tests {
 
         cache_written_output(&mut last_output, "written frame", true);
         assert_eq!(last_output, "written frame");
+    }
+
+    #[test]
+    fn hidden_cached_frame_does_not_keep_viewport_cramped() {
+        assert!(!frame_fills_viewport(2, 20, false, 10));
+        assert!(frame_fills_viewport(2, 20, true, 10));
+        assert!(frame_fills_viewport(10, 2, false, 10));
     }
 
     #[test]

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -318,18 +318,7 @@ pub fn refresh_once() -> Result<()> {
     refresh_once_locked()
 }
 
-pub(crate) fn refresh_once_if_started() -> Result<()> {
-    if is_disabled() || matches!(output(), ProgressOutput::Quiet | ProgressOutput::Text) {
-        return Ok(());
-    }
-    let _refresh_guard = REFRESH_LOCK.lock().unwrap();
-    if !*STARTED.lock().unwrap() {
-        return Ok(());
-    }
-    refresh_once_locked()
-}
-
-fn refresh_once_locked() -> Result<()> {
+pub(crate) fn refresh_once_locked() -> Result<()> {
     let frame = render_frame()?;
     let final_output = process_flex_output(&frame.output);
     let written = write_frame(&final_output, &frame.jobs)?;

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -147,7 +147,10 @@ pub(crate) fn process_flex_output(output: &str) -> String {
 }
 
 /// Writes a rendered frame to the terminal.
-pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()> {
+///
+/// Returns `true` when the frame was written and `false` when a resize guard
+/// deferred it.
+pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<bool> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
     let mut last_frame = LAST_FRAME.lock().unwrap();
@@ -165,7 +168,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
         any_running,
         Instant::now(),
     ) {
-        return Ok(());
+        return Ok(false);
     }
     let (term_height, term_width) = term_size;
     let term_height = term_height as usize;
@@ -178,7 +181,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
     // viewport is tall enough to address it again. Terminal states still get
     // one best-effort final render so completed status is not lost.
     if any_running && previous_height >= term_height {
-        return Ok(());
+        return Ok(false);
     }
     let _sync = SyncUpdate::begin();
     if previous_height > 0 {
@@ -199,7 +202,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
         last_frame.clear();
     }
 
-    Ok(())
+    Ok(true)
 }
 
 pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
@@ -214,6 +217,12 @@ pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
             }
         })
         .sum()
+}
+
+fn cache_written_output(last_output: &mut String, output: &str, written: bool) {
+    if written {
+        output.clone_into(last_output);
+    }
 }
 
 /// Performs one refresh cycle of the progress display.
@@ -240,7 +249,7 @@ pub fn refresh() -> Result<bool> {
     let final_output = process_flex_output(&frame.output);
 
     // Smart refresh: skip terminal write if output unchanged and no spinners animating
-    let mut last_output = LAST_OUTPUT.lock().unwrap();
+    let last_output = LAST_OUTPUT.lock().unwrap();
     let lines = *LINES.lock().unwrap();
     if !any_running && final_output == *last_output && lines > 0 {
         drop(last_output);
@@ -250,10 +259,10 @@ pub fn refresh() -> Result<bool> {
         }
         return Ok(true);
     }
-    *last_output = final_output.clone();
     drop(last_output);
 
-    write_frame(&final_output, &frame.jobs)?;
+    let written = write_frame(&final_output, &frame.jobs)?;
+    cache_written_output(&mut LAST_OUTPUT.lock().unwrap(), &final_output, written);
 
     if !any_running && !any_running_check() {
         *STARTED.lock().unwrap() = false;
@@ -441,6 +450,17 @@ mod tests {
         assert_eq!(render_width(2), 1);
         assert_eq!(render_width(1), 1);
         assert_eq!(render_width(0), 1);
+    }
+
+    #[test]
+    fn deferred_frame_does_not_advance_output_cache() {
+        let mut last_output = "visible frame".to_string();
+
+        cache_written_output(&mut last_output, "deferred frame", false);
+        assert_eq!(last_output, "visible frame");
+
+        cache_written_output(&mut last_output, "written frame", true);
+        assert_eq!(last_output, "written frame");
     }
 
     #[test]

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -1,6 +1,6 @@
 //! Frame rendering and refresh logic for progress display.
 
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tera::{Context, Tera};
@@ -12,56 +12,9 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    JOBS, LAST_FRAME, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate,
-    TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
+    JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate, TERA,
+    TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
-
-const RESIZE_SETTLE_TIME: Duration = Duration::from_millis(100);
-
-fn render_width(terminal_width: usize) -> usize {
-    terminal_width.saturating_sub(1).max(1)
-}
-
-#[derive(Default)]
-struct TerminalResizeState {
-    size: Option<(u16, u16)>,
-    changed_at: Option<Instant>,
-}
-
-impl TerminalResizeState {
-    fn should_defer(
-        &mut self,
-        size: (u16, u16),
-        has_frame: bool,
-        any_running: bool,
-        now: Instant,
-    ) -> bool {
-        if !has_frame || !any_running {
-            self.size = Some(size);
-            self.changed_at = None;
-            return false;
-        }
-
-        if self.size != Some(size) {
-            self.size = Some(size);
-            self.changed_at = Some(now);
-            return true;
-        }
-
-        if self
-            .changed_at
-            .is_some_and(|changed_at| now.duration_since(changed_at) < RESIZE_SETTLE_TIME)
-        {
-            return true;
-        }
-
-        self.changed_at = None;
-        false
-    }
-}
-
-static TERMINAL_RESIZE_STATE: LazyLock<Mutex<TerminalResizeState>> =
-    LazyLock::new(|| Mutex::new(TerminalResizeState::default()));
 
 /// Context for rendering a frame.
 #[derive(Clone)]
@@ -82,7 +35,7 @@ impl Default for RenderContext {
         Self {
             start: Instant::now(),
             now: Instant::now(),
-            width: render_width(term().size().1 as usize),
+            width: term().size().1 as usize,
             tera_ctx,
             indent: 0,
             include_children: true,
@@ -103,7 +56,7 @@ pub(crate) fn prepare_render_context() -> RenderContext {
     let ctx = RENDER_CTX.get_or_init(|| std::sync::Mutex::new(RenderContext::default()));
     let mut ctx_guard = ctx.lock().unwrap();
     ctx_guard.now = Instant::now();
-    ctx_guard.width = render_width(term().size().1 as usize);
+    ctx_guard.width = term().size().1 as usize;
     ctx_guard.clone()
 }
 
@@ -140,7 +93,7 @@ pub(crate) fn render_frame() -> Result<RenderedFrame> {
 /// Processes flex tags in the rendered output.
 pub(crate) fn process_flex_output(output: &str) -> String {
     if output.contains("<clx:flex>") || output.contains("<clx:flex_fill>") {
-        flex(output, render_width(term().size().1 as usize))
+        flex(output, term().size().1 as usize)
     } else {
         output.to_string()
     }
@@ -153,53 +106,41 @@ pub(crate) fn process_flex_output(output: &str) -> String {
 pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<bool> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    let mut last_frame = LAST_FRAME.lock().unwrap();
 
     let _guard = TERM_LOCK.lock().unwrap();
 
-    // Recalculate the previous frame's physical height at the current width.
-    // A terminal resize reflows existing text, so the row count recorded when
-    // the frame was written can point at the wrong starting row.
     let term_size = term.size();
-    let any_running = jobs.iter().any(|job| job.is_running());
-    if TERMINAL_RESIZE_STATE.lock().unwrap().should_defer(
-        term_size,
-        !last_frame.is_empty(),
-        any_running,
-        Instant::now(),
-    ) {
-        return Ok(false);
-    }
     let (term_height, term_width) = term_size;
     let term_height = term_height as usize;
     let term_width = term_width as usize;
-    let previous_height = rendered_height(&last_frame, term_width);
-    // Cursor-up is clamped at the top of the viewport. If a resize makes the
-    // viewport shorter than the existing frame, attempting a redraw cannot
-    // reach and erase the whole frame; each refresh would instead push another
-    // partial copy into scrollback. Leave the existing frame alone until the
-    // viewport is tall enough to address it again. Terminal states still get
-    // one best-effort final render so completed status is not lost.
-    if any_running && previous_height >= term_height {
+    let any_running = jobs.iter().any(|job| job.is_running());
+    let output_height = rendered_height(output, term_width);
+    // Writing a frame that fills the viewport would scroll its anchored first
+    // row out of reach. Keep the current frame until the viewport can contain
+    // the replacement. Terminal states still get one best-effort final render.
+    if any_running && output_height >= term_height {
         return Ok(false);
     }
+
     let _sync = SyncUpdate::begin();
-    if previous_height > 0 {
-        term.move_cursor_up(previous_height)?;
-        term.move_cursor_left(term_width)?;
+    if *lines > 0 {
         term.clear_to_end_of_screen()?;
     }
 
     if !output.is_empty() {
         diagnostics::log_frame(output, jobs);
+        term.hide_cursor()?;
         term.write_line(output)?;
 
-        // Count how many terminal rows were consumed, accounting for wrapping
-        *lines = rendered_height(output, term_width).max(1);
-        *last_frame = output.to_string();
+        // Keep the cursor at the frame origin. Terminal resizes may reflow the
+        // frame below it, but cleanup can always clear from this anchor instead
+        // of reconstructing the previous physical row count.
+        *lines = output_height.max(1);
+        term.move_cursor_up(*lines)?;
+        term.move_cursor_left(term_width)?;
     } else {
         *lines = 0;
-        last_frame.clear();
+        term.show_cursor()?;
     }
 
     Ok(true)
@@ -219,7 +160,7 @@ pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
         .sum()
 }
 
-fn cache_written_output(last_output: &mut String, output: &str, written: bool) {
+pub(crate) fn cache_written_output(last_output: &mut String, output: &str, written: bool) {
     if written {
         output.clone_into(last_output);
     }
@@ -254,6 +195,7 @@ pub fn refresh() -> Result<bool> {
     if !any_running && final_output == *last_output && lines > 0 {
         drop(last_output);
         if !any_running && !any_running_check() {
+            super::state::finish_frame()?;
             *STARTED.lock().unwrap() = false;
             return Ok(false);
         }
@@ -265,6 +207,7 @@ pub fn refresh() -> Result<bool> {
     cache_written_output(&mut LAST_OUTPUT.lock().unwrap(), &final_output, written);
 
     if !any_running && !any_running_check() {
+        super::state::finish_frame()?;
         *STARTED.lock().unwrap() = false;
         return Ok(false);
     }
@@ -285,7 +228,8 @@ pub fn refresh_once() -> Result<()> {
 
     let frame = render_frame()?;
     let final_output = process_flex_output(&frame.output);
-    write_frame(&final_output, &frame.jobs)?;
+    let written = write_frame(&final_output, &frame.jobs)?;
+    cache_written_output(&mut LAST_OUTPUT.lock().unwrap(), &final_output, written);
 
     Ok(())
 }
@@ -445,14 +389,6 @@ mod tests {
     }
 
     #[test]
-    fn render_width_keeps_output_off_the_right_margin() {
-        assert_eq!(render_width(80), 79);
-        assert_eq!(render_width(2), 1);
-        assert_eq!(render_width(1), 1);
-        assert_eq!(render_width(0), 1);
-    }
-
-    #[test]
     fn deferred_frame_does_not_advance_output_cache() {
         let mut last_output = "visible frame".to_string();
 
@@ -461,21 +397,5 @@ mod tests {
 
         cache_written_output(&mut last_output, "written frame", true);
         assert_eq!(last_output, "written frame");
-    }
-
-    #[test]
-    fn active_redraw_waits_for_terminal_size_to_settle() {
-        let mut state = TerminalResizeState::default();
-        let start = Instant::now();
-
-        assert!(!state.should_defer((24, 80), false, true, start));
-        assert!(state.should_defer((24, 60), true, true, start));
-        assert!(state.should_defer(
-            (24, 60),
-            true,
-            true,
-            start + RESIZE_SETTLE_TIME - Duration::from_millis(1)
-        ));
-        assert!(!state.should_defer((24, 60), true, true, start + RESIZE_SETTLE_TIME));
     }
 }

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -106,16 +106,28 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
     let mut last_frame = LAST_FRAME.lock().unwrap();
 
     let _guard = TERM_LOCK.lock().unwrap();
-    let _sync = SyncUpdate::begin();
 
     // Recalculate the previous frame's physical height at the current width.
     // A terminal resize reflows existing text, so the row count recorded when
     // the frame was written can point at the wrong starting row.
-    let term_width = term.size().1 as usize;
+    let (term_height, term_width) = term.size();
+    let term_height = term_height as usize;
+    let term_width = term_width as usize;
     let previous_height = rendered_height(&last_frame, term_width);
+    // Cursor-up is clamped at the top of the viewport. If a resize makes the
+    // viewport shorter than the existing frame, attempting a redraw cannot
+    // reach and erase the whole frame; each refresh would instead push another
+    // partial copy into scrollback. Leave the existing frame alone until the
+    // viewport is tall enough to address it again. Terminal states still get
+    // one best-effort final render so completed status is not lost.
+    let any_running = jobs.iter().any(|job| job.is_running());
+    if any_running && previous_height >= term_height {
+        return Ok(());
+    }
+    let _sync = SyncUpdate::begin();
     if previous_height > 0 {
         term.move_cursor_up(previous_height)?;
-        term.move_cursor_left(term.size().1 as usize)?;
+        term.move_cursor_left(term_width)?;
         term.clear_to_end_of_screen()?;
     }
 

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -16,14 +16,59 @@ use super::state::{
     SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
 
-static LAST_TERMINAL_SIZE: LazyLock<Mutex<Option<(u16, u16)>>> = LazyLock::new(|| Mutex::new(None));
+const RESIZE_SETTLE_TIME: Duration = Duration::from_millis(100);
 
-fn terminal_resized(size: (u16, u16)) -> bool {
-    let mut previous = LAST_TERMINAL_SIZE.lock().unwrap();
-    let resized = previous.is_some_and(|previous| previous != size);
-    *previous = Some(size);
-    resized
+#[derive(Default)]
+struct TerminalResizeState {
+    size: Option<(u16, u16)>,
+    changed_at: Option<Instant>,
 }
+
+#[derive(Debug, PartialEq, Eq)]
+enum ResizeAction {
+    None,
+    ClearAndDefer,
+    Defer,
+    ClearAndRender,
+}
+
+impl TerminalResizeState {
+    fn update(
+        &mut self,
+        size: (u16, u16),
+        has_frame: bool,
+        any_running: bool,
+        now: Instant,
+    ) -> ResizeAction {
+        if !has_frame && self.changed_at.is_none() {
+            self.size = Some(size);
+            return ResizeAction::None;
+        }
+
+        if self.size != Some(size) {
+            self.size = Some(size);
+            if any_running {
+                self.changed_at = Some(now);
+                return ResizeAction::ClearAndDefer;
+            }
+            self.changed_at = None;
+            return ResizeAction::ClearAndRender;
+        }
+
+        if let Some(changed_at) = self.changed_at {
+            if any_running && now.duration_since(changed_at) < RESIZE_SETTLE_TIME {
+                return ResizeAction::Defer;
+            }
+            self.changed_at = None;
+            return ResizeAction::ClearAndRender;
+        }
+
+        ResizeAction::None
+    }
+}
+
+static TERMINAL_RESIZE_STATE: LazyLock<Mutex<TerminalResizeState>> =
+    LazyLock::new(|| Mutex::new(TerminalResizeState::default()));
 
 /// Context for rendering a frame.
 #[derive(Clone)]
@@ -120,11 +165,28 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     let _guard = TERM_LOCK.lock().unwrap();
 
     let term_size = term.size();
-    let resized = terminal_resized(term_size);
+    let any_running = jobs.iter().any(|job| job.is_running());
+    let resize_action = TERMINAL_RESIZE_STATE.lock().unwrap().update(
+        term_size,
+        *lines > 0,
+        any_running,
+        Instant::now(),
+    );
+    match resize_action {
+        ResizeAction::ClearAndDefer => {
+            let _sync = SyncUpdate::begin();
+            term.clear_screen()?;
+            term.hide_cursor()?;
+            *lines = 0;
+            return Ok(false);
+        }
+        ResizeAction::Defer => return Ok(false),
+        ResizeAction::None | ResizeAction::ClearAndRender => {}
+    }
+
     let (term_height, term_width) = term_size;
     let term_height = term_height as usize;
     let term_width = term_width as usize;
-    let any_running = jobs.iter().any(|job| job.is_running());
     let output_height = rendered_height(output, term_width);
     let previous_height = rendered_height(&previous_output, term_width);
     // Once either the old or replacement frame fills the viewport, resizing
@@ -134,7 +196,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     // render.
     if any_running && output_height.max(previous_height) >= term_height {
         let first_cramped = !CRAMPED_VIEWPORT.swap(true, std::sync::atomic::Ordering::Relaxed);
-        if *lines > 0 && (resized || first_cramped) {
+        if *lines > 0 && first_cramped {
             let _sync = SyncUpdate::begin();
             term.clear_screen()?;
             term.hide_cursor()?;
@@ -147,7 +209,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
 
     CRAMPED_VIEWPORT.store(false, std::sync::atomic::Ordering::Relaxed);
     let _sync = SyncUpdate::begin();
-    if resized && *lines > 0 {
+    if resize_action == ResizeAction::ClearAndRender {
         // A terminal can reflow the old frame before clx observes its new
         // dimensions, moving some of that frame into inaccessible scrollback.
         // Reset the visible viewport so the replacement always starts from a
@@ -439,5 +501,33 @@ mod tests {
 
         cache_written_output(&mut last_output, "written frame", true);
         assert_eq!(last_output, "written frame");
+    }
+
+    #[test]
+    fn active_resize_clears_then_waits_for_the_size_to_settle() {
+        let mut state = TerminalResizeState::default();
+        let start = Instant::now();
+
+        assert_eq!(
+            state.update((24, 80), false, true, start),
+            ResizeAction::None
+        );
+        assert_eq!(
+            state.update((24, 60), true, true, start),
+            ResizeAction::ClearAndDefer
+        );
+        assert_eq!(
+            state.update(
+                (24, 60),
+                false,
+                true,
+                start + RESIZE_SETTLE_TIME - Duration::from_millis(1)
+            ),
+            ResizeAction::Defer
+        );
+        assert_eq!(
+            state.update((24, 60), false, true, start + RESIZE_SETTLE_TIME),
+            ResizeAction::ClearAndRender
+        );
     }
 }

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -70,6 +70,10 @@ impl TerminalResizeState {
 static TERMINAL_RESIZE_STATE: LazyLock<Mutex<TerminalResizeState>> =
     LazyLock::new(|| Mutex::new(TerminalResizeState::default()));
 
+pub(crate) fn reset_terminal_resize_state() {
+    *TERMINAL_RESIZE_STATE.lock().unwrap() = TerminalResizeState::default();
+}
+
 /// Context for rendering a frame.
 #[derive(Clone)]
 pub struct RenderContext {

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -1,6 +1,6 @@
 //! Frame rendering and refresh logic for progress display.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use tera::{Context, Tera};
@@ -12,10 +12,18 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    CRAMPED_VIEWPORT, JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, RESTORE_CURSOR_POSITION,
-    SAVE_CURSOR_POSITION, STARTED, STOPPING, SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused,
-    term, update_osc_progress,
+    CRAMPED_VIEWPORT, JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING,
+    SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
+
+static LAST_TERMINAL_SIZE: LazyLock<Mutex<Option<(u16, u16)>>> = LazyLock::new(|| Mutex::new(None));
+
+fn terminal_resized(size: (u16, u16)) -> bool {
+    let mut previous = LAST_TERMINAL_SIZE.lock().unwrap();
+    let resized = previous.is_some_and(|previous| previous != size);
+    *previous = Some(size);
+    resized
+}
 
 /// Context for rendering a frame.
 #[derive(Clone)]
@@ -112,6 +120,7 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     let _guard = TERM_LOCK.lock().unwrap();
 
     let term_size = term.size();
+    let resized = terminal_resized(term_size);
     let (term_height, term_width) = term_size;
     let term_height = term_height as usize;
     let term_width = term_width as usize;
@@ -124,7 +133,8 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     // complete frame fits again. Terminal states still get a best-effort final
     // render.
     if any_running && output_height.max(previous_height) >= term_height {
-        if *lines > 0 && !CRAMPED_VIEWPORT.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        let first_cramped = !CRAMPED_VIEWPORT.swap(true, std::sync::atomic::Ordering::Relaxed);
+        if *lines > 0 && (resized || first_cramped) {
             let _sync = SyncUpdate::begin();
             term.clear_screen()?;
             term.hide_cursor()?;
@@ -137,20 +147,24 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
 
     CRAMPED_VIEWPORT.store(false, std::sync::atomic::Ordering::Relaxed);
     let _sync = SyncUpdate::begin();
-    if *lines > 0 {
-        term.write_str(RESTORE_CURSOR_POSITION)?;
+    if resized && *lines > 0 {
+        // A terminal can reflow the old frame before clx observes its new
+        // dimensions, moving some of that frame into inaccessible scrollback.
+        // Reset the visible viewport so the replacement always starts from a
+        // known position.
+        term.clear_screen()?;
+        *lines = 0;
+    } else if *lines > 0 {
+        term.move_cursor_up(*lines)?;
+        term.move_cursor_left(term_width)?;
         term.clear_to_end_of_screen()?;
     }
 
     if !output.is_empty() {
         diagnostics::log_frame(output, jobs);
-        term.write_str(SAVE_CURSOR_POSITION)?;
         term.hide_cursor()?;
         term.write_line(output)?;
 
-        // Keep the frame origin in the terminal's independent saved-cursor
-        // state. The visible cursor can reflow with the output during a resize;
-        // the next redraw restores this position before clearing.
         *lines = output_height.max(1);
     } else {
         *lines = 0;
@@ -239,7 +253,21 @@ pub fn refresh_once() -> Result<()> {
         return Ok(());
     }
     let _refresh_guard = REFRESH_LOCK.lock().unwrap();
+    refresh_once_locked()
+}
 
+pub(crate) fn refresh_once_if_started() -> Result<()> {
+    if is_disabled() || matches!(output(), ProgressOutput::Quiet | ProgressOutput::Text) {
+        return Ok(());
+    }
+    let _refresh_guard = REFRESH_LOCK.lock().unwrap();
+    if !*STARTED.lock().unwrap() {
+        return Ok(());
+    }
+    refresh_once_locked()
+}
+
+fn refresh_once_locked() -> Result<()> {
     let frame = render_frame()?;
     let final_output = process_flex_output(&frame.output);
     let written = write_frame(&final_output, &frame.jobs)?;

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -1,6 +1,6 @@
 //! Frame rendering and refresh logic for progress display.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use tera::{Context, Tera};
@@ -15,6 +15,49 @@ use super::state::{
     JOBS, LAST_FRAME, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate,
     TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
+
+const RESIZE_SETTLE_TIME: Duration = Duration::from_millis(100);
+
+#[derive(Default)]
+struct TerminalResizeState {
+    size: Option<(u16, u16)>,
+    changed_at: Option<Instant>,
+}
+
+impl TerminalResizeState {
+    fn should_defer(
+        &mut self,
+        size: (u16, u16),
+        has_frame: bool,
+        any_running: bool,
+        now: Instant,
+    ) -> bool {
+        if !has_frame || !any_running {
+            self.size = Some(size);
+            self.changed_at = None;
+            return false;
+        }
+
+        if self.size != Some(size) {
+            self.size = Some(size);
+            self.changed_at = Some(now);
+            return true;
+        }
+
+        if self
+            .changed_at
+            .is_some_and(|changed_at| now.duration_since(changed_at) < RESIZE_SETTLE_TIME)
+        {
+            return true;
+        }
+
+        self.changed_at = None;
+        false
+    }
+}
+
+static TERMINAL_RESIZE_STATE: LazyLock<Mutex<TerminalResizeState>> =
+    LazyLock::new(|| Mutex::new(TerminalResizeState::default()));
 
 /// Context for rendering a frame.
 #[derive(Clone)]
@@ -110,7 +153,17 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
     // Recalculate the previous frame's physical height at the current width.
     // A terminal resize reflows existing text, so the row count recorded when
     // the frame was written can point at the wrong starting row.
-    let (term_height, term_width) = term.size();
+    let term_size = term.size();
+    let any_running = jobs.iter().any(|job| job.is_running());
+    if TERMINAL_RESIZE_STATE.lock().unwrap().should_defer(
+        term_size,
+        !last_frame.is_empty(),
+        any_running,
+        Instant::now(),
+    ) {
+        return Ok(());
+    }
+    let (term_height, term_width) = term_size;
     let term_height = term_height as usize;
     let term_width = term_width as usize;
     let previous_height = rendered_height(&last_frame, term_width);
@@ -120,7 +173,6 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
     // partial copy into scrollback. Leave the existing frame alone until the
     // viewport is tall enough to address it again. Terminal states still get
     // one best-effort final render so completed status is not lost.
-    let any_running = jobs.iter().any(|job| job.is_running());
     if any_running && previous_height >= term_height {
         return Ok(());
     }
@@ -377,5 +429,21 @@ mod tests {
         let output = format!("\x1b[31m{}\x1b[0m", "x".repeat(20));
 
         assert_eq!(rendered_height(&output, 20), 1);
+    }
+
+    #[test]
+    fn active_redraw_waits_for_terminal_size_to_settle() {
+        let mut state = TerminalResizeState::default();
+        let start = Instant::now();
+
+        assert!(!state.should_defer((24, 80), false, true, start));
+        assert!(state.should_defer((24, 60), true, true, start));
+        assert!(state.should_defer(
+            (24, 60),
+            true,
+            true,
+            start + RESIZE_SETTLE_TIME - Duration::from_millis(1)
+        ));
+        assert!(!state.should_defer((24, 60), true, true, start + RESIZE_SETTLE_TIME));
     }
 }

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -12,8 +12,8 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate, TERA,
-    TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
+    JOBS, LAST_FRAME, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate,
+    TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
 
 /// Context for rendering a frame.
@@ -103,13 +103,18 @@ pub(crate) fn process_flex_output(output: &str) -> String {
 pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
+    let mut last_frame = LAST_FRAME.lock().unwrap();
 
     let _guard = TERM_LOCK.lock().unwrap();
     let _sync = SyncUpdate::begin();
 
-    // Clear previous frame
-    if *lines > 0 {
-        term.move_cursor_up(*lines)?;
+    // Recalculate the previous frame's physical height at the current width.
+    // A terminal resize reflows existing text, so the row count recorded when
+    // the frame was written can point at the wrong starting row.
+    let term_width = term.size().1 as usize;
+    let previous_height = rendered_height(&last_frame, term_width);
+    if previous_height > 0 {
+        term.move_cursor_up(previous_height)?;
         term.move_cursor_left(term.size().1 as usize)?;
         term.clear_to_end_of_screen()?;
     }
@@ -119,23 +124,28 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<()>
         term.write_line(output)?;
 
         // Count how many terminal rows were consumed, accounting for wrapping
-        let term_width = term.size().1 as usize;
-        let mut consumed_rows = 0usize;
-        for line in output.lines() {
-            let visible_width = console::measure_text_width(line).max(1);
-            let rows = if term_width == 0 {
-                1
-            } else {
-                (visible_width - 1).checked_div(term_width).unwrap_or(0) + 1
-            };
-            consumed_rows += rows.max(1);
-        }
-        *lines = consumed_rows.max(1);
+        *lines = rendered_height(output, term_width).max(1);
+        *last_frame = output.to_string();
     } else {
         *lines = 0;
+        last_frame.clear();
     }
 
     Ok(())
+}
+
+pub(crate) fn rendered_height(output: &str, width: usize) -> usize {
+    output
+        .lines()
+        .map(|line| {
+            let visible_width = console::measure_text_width(line).max(1);
+            if width == 0 {
+                1
+            } else {
+                (visible_width - 1).checked_div(width).unwrap_or(0) + 1
+            }
+        })
+        .sum()
 }
 
 /// Performs one refresh cycle of the progress display.
@@ -340,5 +350,20 @@ mod tests {
             result,
             "  \x1b[0;31maaaaaaaa\n  \x1b[0;31maaaaaaaa\n  \x1b[0;31maaaaaaaa\n  \x1b[0;31maaaaaaaa\n  \x1b[0;31maa"
         );
+    }
+
+    #[test]
+    fn rendered_height_tracks_terminal_reflow() {
+        let output = "x".repeat(60);
+
+        assert_eq!(rendered_height(&output, 20), 3);
+        assert_eq!(rendered_height(&output, 80), 1);
+    }
+
+    #[test]
+    fn rendered_height_ignores_ansi_width() {
+        let output = format!("\x1b[31m{}\x1b[0m", "x".repeat(20));
+
+        assert_eq!(rendered_height(&output, 20), 1);
     }
 }

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -12,8 +12,8 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING, SyncUpdate, TERA,
-    TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
+    CRAMPED_VIEWPORT, JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING,
+    SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
 };
 
 /// Context for rendering a frame.
@@ -105,6 +105,7 @@ pub(crate) fn process_flex_output(output: &str) -> String {
 /// deferred it.
 pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<bool> {
     let term = term();
+    let previous_output = LAST_OUTPUT.lock().unwrap().clone();
     let mut lines = LINES.lock().unwrap();
 
     let _guard = TERM_LOCK.lock().unwrap();
@@ -115,13 +116,25 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     let term_width = term_width as usize;
     let any_running = jobs.iter().any(|job| job.is_running());
     let output_height = rendered_height(output, term_width);
-    // Writing a frame that fills the viewport would scroll its anchored first
-    // row out of reach. Keep the current frame until the viewport can contain
-    // the replacement. Terminal states still get one best-effort final render.
-    if any_running && output_height >= term_height {
+    let previous_height = rendered_height(&previous_output, term_width);
+    // Once either the old or replacement frame fills the viewport, resizing
+    // can push the anchored origin into scrollback before clx receives
+    // SIGWINCH. Reset the visible viewport once, then suppress output until a
+    // complete frame fits again. Terminal states still get a best-effort final
+    // render.
+    if any_running && output_height.max(previous_height) >= term_height {
+        if *lines > 0 && !CRAMPED_VIEWPORT.swap(true, std::sync::atomic::Ordering::Relaxed) {
+            let _sync = SyncUpdate::begin();
+            term.clear_screen()?;
+            term.hide_cursor()?;
+            *lines = 0;
+        } else {
+            CRAMPED_VIEWPORT.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
         return Ok(false);
     }
 
+    CRAMPED_VIEWPORT.store(false, std::sync::atomic::Ordering::Relaxed);
     let _sync = SyncUpdate::begin();
     if *lines > 0 {
         term.clear_to_end_of_screen()?;

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -334,6 +334,14 @@ pub fn refresh_once() -> Result<()> {
 }
 
 pub(crate) fn refresh_once_locked() -> Result<()> {
+    // The background refresh can finish after a terminal status update wakes it
+    // but before that update reaches its synchronous refresh. In that case the
+    // final frame is already visible and finish_frame() has reset LINES, so a
+    // late write would append a duplicate instead of replacing the frame.
+    if !*STARTED.lock().unwrap() {
+        return Ok(());
+    }
+
     let frame = render_frame()?;
     let final_output = process_flex_output(&frame.output);
     let written = write_frame(&final_output, &frame.jobs)?;
@@ -512,6 +520,21 @@ mod tests {
         assert!(!frame_fills_viewport(2, 20, false, 10));
         assert!(frame_fills_viewport(2, 20, true, 10));
         assert!(frame_fills_viewport(10, 2, false, 10));
+    }
+
+    #[test]
+    fn synchronous_refresh_skips_after_background_stops() {
+        let previous_started = std::mem::replace(&mut *STARTED.lock().unwrap(), false);
+        let mut last_output = LAST_OUTPUT.lock().unwrap();
+        let previous_output = std::mem::replace(&mut *last_output, "visible final frame".into());
+        drop(last_output);
+
+        refresh_once_locked().unwrap();
+
+        let mut last_output = LAST_OUTPUT.lock().unwrap();
+        assert_eq!(*last_output, "visible final frame");
+        *last_output = previous_output;
+        *STARTED.lock().unwrap() = previous_started;
     }
 
     #[test]

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -18,6 +18,10 @@ use super::state::{
 
 const RESIZE_SETTLE_TIME: Duration = Duration::from_millis(100);
 
+fn render_width(terminal_width: usize) -> usize {
+    terminal_width.saturating_sub(1).max(1)
+}
+
 #[derive(Default)]
 struct TerminalResizeState {
     size: Option<(u16, u16)>,
@@ -78,7 +82,7 @@ impl Default for RenderContext {
         Self {
             start: Instant::now(),
             now: Instant::now(),
-            width: term().size().1 as usize,
+            width: render_width(term().size().1 as usize),
             tera_ctx,
             indent: 0,
             include_children: true,
@@ -99,7 +103,7 @@ pub(crate) fn prepare_render_context() -> RenderContext {
     let ctx = RENDER_CTX.get_or_init(|| std::sync::Mutex::new(RenderContext::default()));
     let mut ctx_guard = ctx.lock().unwrap();
     ctx_guard.now = Instant::now();
-    ctx_guard.width = term().size().1 as usize;
+    ctx_guard.width = render_width(term().size().1 as usize);
     ctx_guard.clone()
 }
 
@@ -136,7 +140,7 @@ pub(crate) fn render_frame() -> Result<RenderedFrame> {
 /// Processes flex tags in the rendered output.
 pub(crate) fn process_flex_output(output: &str) -> String {
     if output.contains("<clx:flex>") || output.contains("<clx:flex_fill>") {
-        flex(output, term().size().1 as usize)
+        flex(output, render_width(term().size().1 as usize))
     } else {
         output.to_string()
     }
@@ -429,6 +433,14 @@ mod tests {
         let output = format!("\x1b[31m{}\x1b[0m", "x".repeat(20));
 
         assert_eq!(rendered_height(&output, 20), 1);
+    }
+
+    #[test]
+    fn render_width_keeps_output_off_the_right_margin() {
+        assert_eq!(render_width(80), 79);
+        assert_eq!(render_width(2), 1);
+        assert_eq!(render_width(1), 1);
+        assert_eq!(render_width(0), 1);
     }
 
     #[test]

--- a/src/progress/render.rs
+++ b/src/progress/render.rs
@@ -12,8 +12,9 @@ use super::flex::flex;
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
 use super::state::{
-    CRAMPED_VIEWPORT, JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, STARTED, STOPPING,
-    SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused, term, update_osc_progress,
+    CRAMPED_VIEWPORT, JOBS, LAST_OUTPUT, LINES, REFRESH_LOCK, RENDER_CTX, RESTORE_CURSOR_POSITION,
+    SAVE_CURSOR_POSITION, STARTED, STOPPING, SyncUpdate, TERA, TERM_LOCK, is_disabled, is_paused,
+    term, update_osc_progress,
 };
 
 /// Context for rendering a frame.
@@ -137,20 +138,20 @@ pub(crate) fn write_frame(output: &str, jobs: &[Arc<ProgressJob>]) -> Result<boo
     CRAMPED_VIEWPORT.store(false, std::sync::atomic::Ordering::Relaxed);
     let _sync = SyncUpdate::begin();
     if *lines > 0 {
+        term.write_str(RESTORE_CURSOR_POSITION)?;
         term.clear_to_end_of_screen()?;
     }
 
     if !output.is_empty() {
         diagnostics::log_frame(output, jobs);
+        term.write_str(SAVE_CURSOR_POSITION)?;
         term.hide_cursor()?;
         term.write_line(output)?;
 
-        // Keep the cursor at the frame origin. Terminal resizes may reflow the
-        // frame below it, but cleanup can always clear from this anchor instead
-        // of reconstructing the previous physical row count.
+        // Keep the frame origin in the terminal's independent saved-cursor
+        // state. The visible cursor can reflow with the output during a resize;
+        // the next redraw restores this position before clearing.
         *lines = output_height.max(1);
-        term.move_cursor_up(*lines)?;
-        term.move_cursor_left(term_width)?;
     } else {
         *lines = 0;
         term.show_cursor()?;

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -150,6 +150,12 @@ pub(crate) static LAST_OSC_PERCENTAGE: Mutex<Option<u8>> = Mutex::new(None);
 /// Cache for smart refresh optimization.
 pub(crate) static LAST_OUTPUT: Mutex<String> = Mutex::new(String::new());
 
+/// Last frame written to the terminal.
+///
+/// Keeping the text lets redraws recalculate its physical height after the
+/// terminal reflows it at a different width.
+pub(crate) static LAST_FRAME: Mutex<String> = Mutex::new(String::new());
+
 /// Shared render context for refresh cycles.
 pub(crate) static RENDER_CTX: OnceLock<Mutex<super::render::RenderContext>> = OnceLock::new();
 
@@ -324,6 +330,7 @@ fn start() {
                 Err(err) => {
                     eprintln!("clx: {err:?}");
                     *LINES.lock().unwrap() = 0;
+                    LAST_FRAME.lock().unwrap().clear();
                 }
             }
             if check_resize_signaled() {
@@ -343,6 +350,7 @@ pub fn stop() {
     *STARTED.lock().unwrap() = false;
     // Reset LINES to prevent subsequent stop_clear() from clearing user output
     *LINES.lock().unwrap() = 0;
+    LAST_FRAME.lock().unwrap().clear();
     // Ensure all output is flushed before returning
     let _ = std::io::stderr().flush();
 }
@@ -414,16 +422,19 @@ pub fn clear_jobs() {
 pub(crate) fn clear() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    if *lines > 0 {
+    let mut last_frame = LAST_FRAME.lock().unwrap();
+    let rendered_height = super::render::rendered_height(&last_frame, term.size().1 as usize);
+    if rendered_height > 0 {
         let _guard = TERM_LOCK.lock().unwrap();
         let _sync = SyncUpdate::begin();
-        term.move_cursor_up(*lines)?;
+        term.move_cursor_up(rendered_height)?;
         term.move_cursor_left(term.size().1 as usize)?;
         term.clear_to_end_of_screen()?;
         drop(_sync);
         drop(_guard);
     }
     *lines = 0;
+    last_frame.clear();
     Ok(())
 }
 

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -14,7 +14,7 @@ use console::Term;
 
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
-use super::render::{refresh, refresh_once_locked};
+use super::render::{refresh, refresh_once_locked, reset_terminal_resize_state};
 
 // =============================================================================
 // Environment Variable Controls
@@ -350,6 +350,7 @@ pub fn stop() {
     {
         let _ = refresh_once_locked();
     }
+    reset_terminal_resize_state();
     drop(refresh_guard);
     let _ = finish_frame();
     clear_osc_progress();
@@ -363,6 +364,7 @@ pub fn stop() {
 pub fn stop_clear() {
     let refresh_guard = REFRESH_LOCK.lock().unwrap();
     STOPPING.store(true, Ordering::Relaxed);
+    reset_terminal_resize_state();
     drop(refresh_guard);
     let _ = clear();
     clear_osc_progress();

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -126,6 +126,9 @@ pub(crate) static REFRESH_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::ne
 /// Signal to stop the background refresh thread.
 pub(crate) static STOPPING: AtomicBool = AtomicBool::new(false);
 
+/// Whether output is suppressed because a complete frame cannot fit.
+pub(crate) static CRAMPED_VIEWPORT: AtomicBool = AtomicBool::new(false);
+
 /// Channel to notify the background thread of updates.
 static NOTIFY: Mutex<Option<mpsc::Sender<()>>> = Mutex::new(None);
 
@@ -324,6 +327,7 @@ fn start() {
                 Err(err) => {
                     eprintln!("clx: {err:?}");
                     *LINES.lock().unwrap() = 0;
+                    CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
                     let _ = term().show_cursor();
                 }
             }
@@ -343,6 +347,7 @@ pub fn stop() {
     let _ = finish_frame();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;
+    CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
     // Ensure all output is flushed before returning
     let _ = std::io::stderr().flush();
 }
@@ -353,6 +358,7 @@ pub fn stop_clear() {
     let _ = clear();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;
+    CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
     // Ensure all output is flushed before returning
     let _ = std::io::stderr().flush();
 }
@@ -414,13 +420,14 @@ pub fn clear_jobs() {
 pub(crate) fn clear() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
+    let _guard = TERM_LOCK.lock().unwrap();
+    let _sync = SyncUpdate::begin();
     if *lines > 0 {
-        let _guard = TERM_LOCK.lock().unwrap();
-        let _sync = SyncUpdate::begin();
         term.clear_to_end_of_screen()?;
-        term.show_cursor()?;
     }
+    term.show_cursor()?;
     *lines = 0;
+    CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
     Ok(())
 }
 
@@ -436,6 +443,7 @@ pub(crate) fn finish_frame() -> crate::Result<()> {
         term.show_cursor()?;
     }
     *lines = 0;
+    CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
     Ok(())
 }
 

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -14,7 +14,7 @@ use console::Term;
 
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
-use super::render::{refresh, refresh_once};
+use super::render::{refresh, refresh_once_if_started};
 
 // =============================================================================
 // Environment Variable Controls
@@ -64,8 +64,6 @@ pub static TERM_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 /// than probing for support, matching Homebrew/brew#23264.
 const BEGIN_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026h";
 const END_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026l";
-pub(crate) const SAVE_CURSOR_POSITION: &str = "\x1b[s";
-pub(crate) const RESTORE_CURSOR_POSITION: &str = "\x1b[u";
 
 /// Nesting depth of open synchronized updates. Mode 2026 is a set/reset flag,
 /// not a counter, so a nested reset would end the outer update early: only the
@@ -345,7 +343,7 @@ fn start() {
 /// Stops the progress display and renders the final state.
 pub fn stop() {
     STOPPING.store(true, Ordering::Relaxed);
-    let _ = refresh_once();
+    let _ = refresh_once_if_started();
     let _ = finish_frame();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;
@@ -425,7 +423,8 @@ pub(crate) fn clear() -> crate::Result<()> {
     let _guard = TERM_LOCK.lock().unwrap();
     let _sync = SyncUpdate::begin();
     if *lines > 0 {
-        term.write_str(RESTORE_CURSOR_POSITION)?;
+        term.move_cursor_up(*lines)?;
+        term.move_cursor_left(term.size().1 as usize)?;
         term.clear_to_end_of_screen()?;
     }
     term.show_cursor()?;
@@ -438,7 +437,7 @@ pub(crate) fn clear() -> crate::Result<()> {
 pub(crate) fn finish_frame() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    if *lines > 0 {
+    if !is_disabled() && output() == ProgressOutput::UI {
         let _guard = TERM_LOCK.lock().unwrap();
         let _sync = SyncUpdate::begin();
         term.show_cursor()?;

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -14,7 +14,7 @@ use console::Term;
 
 use super::job::ProgressJob;
 use super::output::{ProgressOutput, output};
-use super::render::{refresh, refresh_once_if_started};
+use super::render::{refresh, refresh_once_locked};
 
 // =============================================================================
 // Environment Variable Controls
@@ -342,8 +342,15 @@ fn start() {
 
 /// Stops the progress display and renders the final state.
 pub fn stop() {
+    let refresh_guard = REFRESH_LOCK.lock().unwrap();
     STOPPING.store(true, Ordering::Relaxed);
-    let _ = refresh_once_if_started();
+    if *STARTED.lock().unwrap()
+        && !is_disabled()
+        && !matches!(output(), ProgressOutput::Quiet | ProgressOutput::Text)
+    {
+        let _ = refresh_once_locked();
+    }
+    drop(refresh_guard);
     let _ = finish_frame();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;
@@ -354,7 +361,9 @@ pub fn stop() {
 
 /// Stops the progress display and clears it from the screen.
 pub fn stop_clear() {
+    let refresh_guard = REFRESH_LOCK.lock().unwrap();
     STOPPING.store(true, Ordering::Relaxed);
+    drop(refresh_guard);
     let _ = clear();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -64,6 +64,8 @@ pub static TERM_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 /// than probing for support, matching Homebrew/brew#23264.
 const BEGIN_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026h";
 const END_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026l";
+pub(crate) const SAVE_CURSOR_POSITION: &str = "\x1b[s";
+pub(crate) const RESTORE_CURSOR_POSITION: &str = "\x1b[u";
 
 /// Nesting depth of open synchronized updates. Mode 2026 is a set/reset flag,
 /// not a counter, so a nested reset would end the outer update early: only the
@@ -423,6 +425,7 @@ pub(crate) fn clear() -> crate::Result<()> {
     let _guard = TERM_LOCK.lock().unwrap();
     let _sync = SyncUpdate::begin();
     if *lines > 0 {
+        term.write_str(RESTORE_CURSOR_POSITION)?;
         term.clear_to_end_of_screen()?;
     }
     term.show_cursor()?;
@@ -438,8 +441,6 @@ pub(crate) fn finish_frame() -> crate::Result<()> {
     if *lines > 0 {
         let _guard = TERM_LOCK.lock().unwrap();
         let _sync = SyncUpdate::begin();
-        term.move_cursor_down(*lines)?;
-        term.move_cursor_left(term.size().1 as usize)?;
         term.show_cursor()?;
     }
     *lines = 0;

--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -150,12 +150,6 @@ pub(crate) static LAST_OSC_PERCENTAGE: Mutex<Option<u8>> = Mutex::new(None);
 /// Cache for smart refresh optimization.
 pub(crate) static LAST_OUTPUT: Mutex<String> = Mutex::new(String::new());
 
-/// Last frame written to the terminal.
-///
-/// Keeping the text lets redraws recalculate its physical height after the
-/// terminal reflows it at a different width.
-pub(crate) static LAST_FRAME: Mutex<String> = Mutex::new(String::new());
-
 /// Shared render context for refresh cycles.
 pub(crate) static RENDER_CTX: OnceLock<Mutex<super::render::RenderContext>> = OnceLock::new();
 
@@ -330,7 +324,7 @@ fn start() {
                 Err(err) => {
                     eprintln!("clx: {err:?}");
                     *LINES.lock().unwrap() = 0;
-                    LAST_FRAME.lock().unwrap().clear();
+                    let _ = term().show_cursor();
                 }
             }
             if check_resize_signaled() {
@@ -346,11 +340,9 @@ fn start() {
 pub fn stop() {
     STOPPING.store(true, Ordering::Relaxed);
     let _ = refresh_once();
+    let _ = finish_frame();
     clear_osc_progress();
     *STARTED.lock().unwrap() = false;
-    // Reset LINES to prevent subsequent stop_clear() from clearing user output
-    *LINES.lock().unwrap() = 0;
-    LAST_FRAME.lock().unwrap().clear();
     // Ensure all output is flushed before returning
     let _ = std::io::stderr().flush();
 }
@@ -422,19 +414,28 @@ pub fn clear_jobs() {
 pub(crate) fn clear() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    let mut last_frame = LAST_FRAME.lock().unwrap();
-    let rendered_height = super::render::rendered_height(&last_frame, term.size().1 as usize);
-    if rendered_height > 0 {
+    if *lines > 0 {
         let _guard = TERM_LOCK.lock().unwrap();
         let _sync = SyncUpdate::begin();
-        term.move_cursor_up(rendered_height)?;
-        term.move_cursor_left(term.size().1 as usize)?;
         term.clear_to_end_of_screen()?;
-        drop(_sync);
-        drop(_guard);
+        term.show_cursor()?;
     }
     *lines = 0;
-    last_frame.clear();
+    Ok(())
+}
+
+/// Leaves the final frame visible and restores the cursor below it.
+pub(crate) fn finish_frame() -> crate::Result<()> {
+    let term = term();
+    let mut lines = LINES.lock().unwrap();
+    if *lines > 0 {
+        let _guard = TERM_LOCK.lock().unwrap();
+        let _sync = SyncUpdate::begin();
+        term.move_cursor_down(*lines)?;
+        term.move_cursor_left(term.size().1 as usize)?;
+        term.show_cursor()?;
+    }
+    *lines = 0;
     Ok(())
 }
 

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -59,10 +59,26 @@ fn resize_clears_the_reflowed_frame_height() {
 
     let mut initial = Vec::new();
     assert!(
-        wait_for_frames(&rx, &mut initial, 1),
+        wait_for_frames(&rx, &mut initial, 1, Duration::from_secs(10)),
         "progress display did not render its initial frame"
     );
     while rx.try_recv().is_ok() {}
+
+    pair.master
+        .resize(PtySize {
+            rows: 2,
+            cols: 20,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("shrink pty");
+
+    let mut cramped = Vec::new();
+    assert!(
+        !wait_for_frames(&rx, &mut cramped, 1, Duration::from_secs(1)),
+        "redrew a frame that could not be fully cleared: {}",
+        String::from_utf8_lossy(&cramped).escape_debug()
+    );
 
     pair.master
         .resize(PtySize {
@@ -75,7 +91,7 @@ fn resize_clears_the_reflowed_frame_height() {
 
     let mut resized = Vec::new();
     assert!(
-        wait_for_frames(&rx, &mut resized, 1),
+        wait_for_frames(&rx, &mut resized, 1, Duration::from_secs(10)),
         "progress display did not redraw after resize"
     );
 
@@ -92,8 +108,13 @@ fn resize_clears_the_reflowed_frame_height() {
     );
 }
 
-fn wait_for_frames(rx: &Receiver<Vec<u8>>, output: &mut Vec<u8>, expected: usize) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(10);
+fn wait_for_frames(
+    rx: &Receiver<Vec<u8>>,
+    output: &mut Vec<u8>,
+    expected: usize,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
     while occurrences(output, END) < expected {
         let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
             return false;

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -1,4 +1,4 @@
-//! Verifies that redraw cleanup follows the terminal's reflowed frame height.
+//! Verifies that redraws stay anchored while the terminal changes size.
 #![cfg(unix)]
 
 use std::io::Read;
@@ -74,17 +74,16 @@ fn resize_clears_the_reflowed_frame_height() {
             })
             .expect("resize pty while dragging");
 
-        let mut moving = Vec::new();
+        let mut resized = Vec::new();
         assert!(
-            !wait_for_frames(&rx, &mut moving, 1, Duration::from_millis(50)),
-            "redrew before the terminal size settled: {}",
-            String::from_utf8_lossy(&moving).escape_debug()
+            wait_for_frames(&rx, &mut resized, 1, Duration::from_secs(3)),
+            "did not redraw at {cols} columns: {}",
+            String::from_utf8_lossy(&resized).escape_debug()
         );
     }
 
-    // The cursor rests on the row after write_line's trailing newline. A
-    // three-row frame in a three-row viewport has already pushed its first
-    // row into scrollback, so even the equal-height case cannot be cleared.
+    // A frame that fills the viewport would scroll its anchored first row into
+    // scrollback, so keep the existing frame until there is room.
     pair.master
         .resize(PtySize {
             rows: 3,
@@ -137,10 +136,15 @@ fn resize_clears_the_reflowed_frame_height() {
     reader_thread.join().expect("join reader");
 
     let frame = first_frame(&resized).unwrap_or(&resized);
+    assert!(
+        frame.windows(4).any(|window| window == b"\x1b[0J"),
+        "redraw did not clear downward from the frame anchor: {}",
+        String::from_utf8_lossy(frame).escape_debug()
+    );
     assert_eq!(
         cursor_up_amount(frame),
         Some(1),
-        "redraw did not clear the previous frame at its reflowed height: {}",
+        "redraw did not return the cursor to the frame anchor: {}",
         String::from_utf8_lossy(frame).escape_debug()
     );
 }
@@ -174,9 +178,18 @@ fn first_frame(output: &[u8]) -> Option<&[u8]> {
 }
 
 fn cursor_up_amount(frame: &[u8]) -> Option<usize> {
-    let start = frame.windows(2).position(|window| window == b"\x1b[")? + 2;
-    let end = frame[start..].iter().position(|byte| *byte == b'A')? + start;
-    std::str::from_utf8(&frame[start..end]).ok()?.parse().ok()
+    frame.windows(2).enumerate().find_map(|(index, window)| {
+        if window != b"\x1b[" {
+            return None;
+        }
+        let digits = &frame[index + 2..];
+        let end = digits.iter().position(|byte| *byte == b'A')?;
+        if digits[..end].iter().all(u8::is_ascii_digit) {
+            std::str::from_utf8(&digits[..end]).ok()?.parse().ok()
+        } else {
+            None
+        }
+    })
 }
 
 fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -2,6 +2,7 @@
 #![cfg(unix)]
 
 use std::io::Read;
+use std::process::Command;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -10,8 +11,6 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 const BEGIN: &[u8] = b"\x1b[?2026h";
 const END: &[u8] = b"\x1b[?2026l";
-const SAVE_CURSOR: &[u8] = b"\x1b[s";
-const RESTORE_CURSOR: &[u8] = b"\x1b[u";
 
 #[test]
 fn resize_child_scenario() {
@@ -28,6 +27,88 @@ fn resize_child_scenario() {
     clx::progress::stop();
 
     std::process::exit(0);
+}
+
+#[test]
+fn cramped_stop_child_scenario() {
+    if std::env::var_os("CLX_CRAMPED_STOP_SCENARIO").is_none() {
+        return;
+    }
+
+    use clx::progress::{ProgressJobBuilder, set_interval};
+
+    set_interval(Duration::from_millis(25));
+    let _job = ProgressJobBuilder::new().body(&"x".repeat(60)).start();
+    thread::sleep(Duration::from_millis(1500));
+    clx::progress::stop();
+
+    std::process::exit(0);
+}
+
+#[test]
+fn tmux_resize_child_scenario() {
+    if std::env::var_os("CLX_TMUX_RESIZE_SCENARIO").is_none() {
+        return;
+    }
+
+    use clx::progress::{ProgressJobBuilder, set_interval};
+
+    set_interval(Duration::from_millis(25));
+    let _jobs = ["TMUX_ROW_ALPHA", "TMUX_ROW_BRAVO", "TMUX_ROW_CHARLIE"].map(|label| {
+        ProgressJobBuilder::new()
+            .body(&format!("{{{{ spinner() }}}} {label}"))
+            .start()
+    });
+    thread::sleep(Duration::from_secs(30));
+
+    std::process::exit(0);
+}
+
+#[test]
+fn tmux_resize_keeps_one_copy_of_each_progress_row() {
+    let Some(tmux) = std::env::var_os("CLX_TMUX_BIN") else {
+        return;
+    };
+
+    let socket = format!("clx-resize-test-{}", std::process::id());
+    let session = "clx-resize";
+    let test_binary = std::env::current_exe().expect("current_exe");
+    let child_command = format!(
+        "env CLX_TMUX_RESIZE_SCENARIO=1 {} --exact tmux_resize_child_scenario --nocapture",
+        test_binary.display()
+    );
+    let cleanup = TmuxCleanup {
+        binary: tmux.clone(),
+        socket: socket.clone(),
+    };
+
+    let status = Command::new(&tmux)
+        .args([
+            "-L",
+            &socket,
+            "-f",
+            "/dev/null",
+            "new-session",
+            "-d",
+            "-x",
+            "120",
+            "-y",
+            "24",
+            "-s",
+            session,
+            &child_command,
+        ])
+        .status()
+        .expect("start tmux");
+    assert!(status.success(), "tmux new-session failed");
+
+    assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
+    resize_tmux(&tmux, &socket, session, 40);
+    assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
+    resize_tmux(&tmux, &socket, session, 120);
+    assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
+
+    drop(cleanup);
 }
 
 #[test]
@@ -84,8 +165,8 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
         );
         let frame = first_frame(&resized).unwrap_or(&resized);
         assert!(
-            contains(frame, RESTORE_CURSOR) && contains(frame, SAVE_CURSOR),
-            "redraw did not restore and refresh the saved origin: {}",
+            frame.windows(4).any(|window| window == b"\x1b[2J"),
+            "resize redraw did not reset the visible viewport: {}",
             String::from_utf8_lossy(frame).escape_debug()
         );
     }
@@ -151,10 +232,150 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
 
     let frame = first_frame(&resized).unwrap_or(&resized);
     assert!(
-        contains(frame, SAVE_CURSOR),
-        "recovered frame did not save its new origin: {}",
+        String::from_utf8_lossy(frame).contains('x'),
+        "recovered frame did not render its output: {}",
         String::from_utf8_lossy(frame).escape_debug()
     );
+}
+
+#[test]
+fn stop_restores_cursor_after_cramped_viewport_suppression() {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 20,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(std::env::current_exe().expect("current_exe"));
+    cmd.args(["--exact", "cramped_stop_child_scenario", "--nocapture"]);
+    cmd.env("CLX_CRAMPED_STOP_SCENARIO", "1");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn child");
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = thread::spawn(move || {
+        let mut chunk = [0; 4096];
+        while let Ok(count) = reader.read(&mut chunk) {
+            if count == 0 || tx.send(chunk[..count].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut initial = Vec::new();
+    assert!(
+        wait_for_frames(&rx, &mut initial, 1, Duration::from_secs(5)),
+        "progress display did not render its initial frame"
+    );
+    pair.master
+        .resize(PtySize {
+            rows: 2,
+            cols: 20,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("shrink pty");
+
+    let mut stopped = Vec::new();
+    assert!(
+        wait_for_frames(&rx, &mut stopped, 1, Duration::from_secs(3)),
+        "cramped viewport did not emit a reset"
+    );
+    child.wait().expect("wait child");
+    while let Ok(chunk) = rx.recv_timeout(Duration::from_millis(100)) {
+        stopped.extend(chunk);
+    }
+    drop(pair.master);
+    reader_thread.join().expect("join reader");
+
+    let reset = stopped
+        .windows(4)
+        .position(|window| window == b"\x1b[2J")
+        .expect("cramped viewport did not clear");
+    assert!(
+        stopped[reset..]
+            .windows(6)
+            .any(|window| window == b"\x1b[?25h"),
+        "stop did not restore cursor visibility after viewport suppression: {}",
+        String::from_utf8_lossy(&stopped).escape_debug()
+    );
+}
+
+struct TmuxCleanup {
+    binary: std::ffi::OsString,
+    socket: String,
+}
+
+impl Drop for TmuxCleanup {
+    fn drop(&mut self) {
+        let _ = Command::new(&self.binary)
+            .args(["-L", &self.socket, "kill-server"])
+            .status();
+    }
+}
+
+fn resize_tmux(tmux: &std::ffi::OsStr, socket: &str, session: &str, columns: usize) {
+    let status = Command::new(tmux)
+        .args([
+            "-L",
+            socket,
+            "resize-window",
+            "-t",
+            session,
+            "-x",
+            &columns.to_string(),
+            "-y",
+            "24",
+        ])
+        .status()
+        .expect("resize tmux");
+    assert!(status.success(), "tmux resize-window failed");
+}
+
+fn assert_unique_tmux_rows(tmux: &std::ffi::OsStr, socket: &str, session: &str, timeout: Duration) {
+    const LABELS: [&str; 3] = ["TMUX_ROW_ALPHA", "TMUX_ROW_BRAVO", "TMUX_ROW_CHARLIE"];
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let output = Command::new(tmux)
+            .args(["-L", socket, "capture-pane", "-p", "-t", session])
+            .output()
+            .expect("capture tmux pane");
+        assert!(output.status.success(), "tmux capture-pane failed");
+        let screen = String::from_utf8_lossy(&output.stdout);
+        let counts = LABELS.map(|label| screen.matches(label).count());
+        if counts == [1, 1, 1] {
+            // Let several stable-size refreshes run too: this catches terminals
+            // that ignore an unsupported cursor save/restore sequence.
+            thread::sleep(Duration::from_millis(150));
+            let stable = Command::new(tmux)
+                .args(["-L", socket, "capture-pane", "-p", "-t", session])
+                .output()
+                .expect("capture stable tmux pane");
+            let stable_screen = String::from_utf8_lossy(&stable.stdout);
+            let stable_counts = LABELS.map(|label| stable_screen.matches(label).count());
+            assert_eq!(
+                stable_counts,
+                [1, 1, 1],
+                "progress rows accumulated in tmux:\n{stable_screen}"
+            );
+            return;
+        }
+        assert!(
+            counts.iter().all(|count| *count <= 1),
+            "progress rows were duplicated in tmux:\n{screen}"
+        );
+        assert!(
+            Instant::now() < deadline,
+            "progress rows did not appear in tmux:\n{screen}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
 }
 
 fn wait_for_frames(
@@ -183,12 +404,6 @@ fn first_frame(output: &[u8]) -> Option<&[u8]> {
     let rest = &output[start + BEGIN.len()..];
     let end = rest.windows(END.len()).position(|window| window == END)?;
     Some(&rest[..end])
-}
-
-fn contains(haystack: &[u8], needle: &[u8]) -> bool {
-    haystack
-        .windows(needle.len())
-        .any(|window| window == needle)
 }
 
 fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -20,7 +20,7 @@ fn resize_child_scenario() {
 
     use clx::progress::{ProgressJobBuilder, ProgressStatus, set_interval};
 
-    set_interval(Duration::from_millis(800));
+    set_interval(Duration::from_millis(25));
     let job = ProgressJobBuilder::new().body(&"x".repeat(60)).start();
     thread::sleep(Duration::from_secs(4));
     job.set_status(ProgressStatus::Done);
@@ -103,9 +103,15 @@ fn tmux_resize_keeps_one_copy_of_each_progress_row() {
     assert!(status.success(), "tmux new-session failed");
 
     assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
-    resize_tmux(&tmux, &socket, session, 40);
+    for columns in (40..=110).rev().step_by(10) {
+        resize_tmux(&tmux, &socket, session, columns);
+        thread::sleep(Duration::from_millis(20));
+    }
     assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
-    resize_tmux(&tmux, &socket, session, 120);
+    for columns in (50..=120).step_by(10) {
+        resize_tmux(&tmux, &socket, session, columns);
+        thread::sleep(Duration::from_millis(20));
+    }
     assert_unique_tmux_rows(&tmux, &socket, session, Duration::from_secs(10));
 
     drop(cleanup);
@@ -159,14 +165,19 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
 
         let mut resized = Vec::new();
         assert!(
-            wait_for_frames(&rx, &mut resized, 1, Duration::from_secs(3)),
+            wait_for_frames(&rx, &mut resized, 2, Duration::from_secs(3)),
             "did not redraw at {cols} columns: {}",
             String::from_utf8_lossy(&resized).escape_debug()
         );
-        let frame = first_frame(&resized).unwrap_or(&resized);
+        let frame = synchronized_frame(&resized, 1).unwrap_or(&resized);
         assert!(
             frame.windows(4).any(|window| window == b"\x1b[2J"),
-            "resize redraw did not reset the visible viewport: {}",
+            "settled resize redraw did not reset the visible viewport: {}",
+            String::from_utf8_lossy(frame).escape_debug()
+        );
+        assert!(
+            String::from_utf8_lossy(frame).contains('x'),
+            "settled resize redraw did not contain the new frame: {}",
             String::from_utf8_lossy(frame).escape_debug()
         );
     }
@@ -206,9 +217,16 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
 
     let mut cramped = Vec::new();
     assert!(
-        !wait_for_frames(&rx, &mut cramped, 1, Duration::from_secs(1)),
-        "redrew a frame that could not be fully cleared: {}",
+        wait_for_frames(&rx, &mut cramped, 1, Duration::from_secs(3)),
+        "did not clear again while the cramped terminal kept resizing: {}",
         String::from_utf8_lossy(&cramped).escape_debug()
+    );
+    let cramped_reset = first_frame(&cramped).unwrap_or(&cramped);
+    assert!(
+        cramped_reset.windows(4).any(|window| window == b"\x1b[2J")
+            && !String::from_utf8_lossy(cramped_reset).contains('x'),
+        "cramped resize did not remain blank: {}",
+        String::from_utf8_lossy(cramped_reset).escape_debug()
     );
 
     pair.master
@@ -222,7 +240,7 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
 
     let mut resized = Vec::new();
     assert!(
-        wait_for_frames(&rx, &mut resized, 1, Duration::from_secs(10)),
+        wait_for_frames(&rx, &mut resized, 2, Duration::from_secs(10)),
         "progress display did not redraw after resize"
     );
 
@@ -230,7 +248,7 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
     drop(pair.master);
     reader_thread.join().expect("join reader");
 
-    let frame = first_frame(&resized).unwrap_or(&resized);
+    let frame = synchronized_frame(&resized, 1).unwrap_or(&resized);
     assert!(
         String::from_utf8_lossy(frame).contains('x'),
         "recovered frame did not render its output: {}",
@@ -359,12 +377,13 @@ fn assert_unique_tmux_rows(tmux: &std::ffi::OsStr, socket: &str, session: &str, 
                 .expect("capture stable tmux pane");
             let stable_screen = String::from_utf8_lossy(&stable.stdout);
             let stable_counts = LABELS.map(|label| stable_screen.matches(label).count());
-            assert_eq!(
-                stable_counts,
-                [1, 1, 1],
+            if stable_counts == [1, 1, 1] {
+                return;
+            }
+            assert!(
+                stable_counts.iter().all(|count| *count <= 1),
                 "progress rows accumulated in tmux:\n{stable_screen}"
             );
-            return;
         }
         assert!(
             counts.iter().all(|count| *count <= 1),
@@ -398,10 +417,21 @@ fn wait_for_frames(
 }
 
 fn first_frame(output: &[u8]) -> Option<&[u8]> {
-    let start = output
-        .windows(BEGIN.len())
-        .position(|window| window == BEGIN)?;
-    let rest = &output[start + BEGIN.len()..];
+    synchronized_frame(output, 0)
+}
+
+fn synchronized_frame(output: &[u8], index: usize) -> Option<&[u8]> {
+    let mut rest = output;
+    for frame_index in 0..=index {
+        let start = rest
+            .windows(BEGIN.len())
+            .position(|window| window == BEGIN)?;
+        rest = &rest[start + BEGIN.len()..];
+        if frame_index < index {
+            let end = rest.windows(END.len()).position(|window| window == END)?;
+            rest = &rest[end + END.len()..];
+        }
+    }
     let end = rest.windows(END.len()).position(|window| window == END)?;
     Some(&rest[..end])
 }

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -64,6 +64,24 @@ fn resize_clears_the_reflowed_frame_height() {
     );
     while rx.try_recv().is_ok() {}
 
+    for cols in [30, 40] {
+        pair.master
+            .resize(PtySize {
+                rows: 24,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("resize pty while dragging");
+
+        let mut moving = Vec::new();
+        assert!(
+            !wait_for_frames(&rx, &mut moving, 1, Duration::from_millis(50)),
+            "redrew before the terminal size settled: {}",
+            String::from_utf8_lossy(&moving).escape_debug()
+        );
+    }
+
     // The cursor rests on the row after write_line's trailing newline. A
     // three-row frame in a three-row viewport has already pushed its first
     // row into scrollback, so even the equal-height case cannot be cleared.

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -10,6 +10,8 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 const BEGIN: &[u8] = b"\x1b[?2026h";
 const END: &[u8] = b"\x1b[?2026l";
+const SAVE_CURSOR: &[u8] = b"\x1b[s";
+const RESTORE_CURSOR: &[u8] = b"\x1b[u";
 
 #[test]
 fn resize_child_scenario() {
@@ -80,6 +82,12 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
             "did not redraw at {cols} columns: {}",
             String::from_utf8_lossy(&resized).escape_debug()
         );
+        let frame = first_frame(&resized).unwrap_or(&resized);
+        assert!(
+            contains(frame, RESTORE_CURSOR) && contains(frame, SAVE_CURSOR),
+            "redraw did not restore and refresh the saved origin: {}",
+            String::from_utf8_lossy(frame).escape_debug()
+        );
     }
 
     // A frame that fills the viewport would scroll its anchored first row into
@@ -142,10 +150,9 @@ fn resize_resets_a_frame_that_outgrows_the_viewport() {
     reader_thread.join().expect("join reader");
 
     let frame = first_frame(&resized).unwrap_or(&resized);
-    assert_eq!(
-        cursor_up_amount(frame),
-        Some(1),
-        "redraw did not return the cursor to the frame anchor: {}",
+    assert!(
+        contains(frame, SAVE_CURSOR),
+        "recovered frame did not save its new origin: {}",
         String::from_utf8_lossy(frame).escape_debug()
     );
 }
@@ -178,19 +185,10 @@ fn first_frame(output: &[u8]) -> Option<&[u8]> {
     Some(&rest[..end])
 }
 
-fn cursor_up_amount(frame: &[u8]) -> Option<usize> {
-    frame.windows(2).enumerate().find_map(|(index, window)| {
-        if window != b"\x1b[" {
-            return None;
-        }
-        let digits = &frame[index + 2..];
-        let end = digits.iter().position(|byte| *byte == b'A')?;
-        if digits[..end].iter().all(u8::is_ascii_digit) {
-            std::str::from_utf8(&digits[..end]).ok()?.parse().ok()
-        } else {
-            None
-        }
-    })
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -1,0 +1,129 @@
+//! Verifies that redraw cleanup follows the terminal's reflowed frame height.
+#![cfg(unix)]
+
+use std::io::Read;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+const BEGIN: &[u8] = b"\x1b[?2026h";
+const END: &[u8] = b"\x1b[?2026l";
+
+#[test]
+fn resize_child_scenario() {
+    if std::env::var_os("CLX_RESIZE_PTY_SCENARIO").is_none() {
+        return;
+    }
+
+    use clx::progress::{ProgressJobBuilder, ProgressStatus, set_interval};
+
+    set_interval(Duration::from_millis(800));
+    let job = ProgressJobBuilder::new().body(&"x".repeat(60)).start();
+    thread::sleep(Duration::from_secs(2));
+    job.set_status(ProgressStatus::Done);
+    clx::progress::stop();
+
+    std::process::exit(0);
+}
+
+#[test]
+fn resize_clears_the_reflowed_frame_height() {
+    let pair = native_pty_system()
+        .openpty(PtySize {
+            rows: 24,
+            cols: 20,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("openpty");
+
+    let mut cmd = CommandBuilder::new(std::env::current_exe().expect("current_exe"));
+    cmd.args(["--exact", "resize_child_scenario", "--nocapture"]);
+    cmd.env("CLX_RESIZE_PTY_SCENARIO", "1");
+
+    let mut child = pair.slave.spawn_command(cmd).expect("spawn child");
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().expect("clone reader");
+    let (tx, rx) = mpsc::channel();
+    let reader_thread = thread::spawn(move || {
+        let mut chunk = [0; 4096];
+        while let Ok(count) = reader.read(&mut chunk) {
+            if count == 0 || tx.send(chunk[..count].to_vec()).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut initial = Vec::new();
+    assert!(
+        wait_for_frames(&rx, &mut initial, 1),
+        "progress display did not render its initial frame"
+    );
+    while rx.try_recv().is_ok() {}
+
+    pair.master
+        .resize(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("resize pty");
+
+    let mut resized = Vec::new();
+    assert!(
+        wait_for_frames(&rx, &mut resized, 1),
+        "progress display did not redraw after resize"
+    );
+
+    child.wait().expect("wait child");
+    drop(pair.master);
+    reader_thread.join().expect("join reader");
+
+    let frame = first_frame(&resized).unwrap_or(&resized);
+    assert_eq!(
+        cursor_up_amount(frame),
+        Some(1),
+        "redraw did not clear the previous frame at its reflowed height: {}",
+        String::from_utf8_lossy(frame).escape_debug()
+    );
+}
+
+fn wait_for_frames(rx: &Receiver<Vec<u8>>, output: &mut Vec<u8>, expected: usize) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while occurrences(output, END) < expected {
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return false;
+        };
+        match rx.recv_timeout(remaining) {
+            Ok(chunk) => output.extend(chunk),
+            Err(_) => return false,
+        }
+    }
+    true
+}
+
+fn first_frame(output: &[u8]) -> Option<&[u8]> {
+    let start = output
+        .windows(BEGIN.len())
+        .position(|window| window == BEGIN)?;
+    let rest = &output[start + BEGIN.len()..];
+    let end = rest.windows(END.len()).position(|window| window == END)?;
+    Some(&rest[..end])
+}
+
+fn cursor_up_amount(frame: &[u8]) -> Option<usize> {
+    let start = frame.windows(2).position(|window| window == b"\x1b[")? + 2;
+    let end = frame[start..].iter().position(|byte| *byte == b'A')? + start;
+    std::str::from_utf8(&frame[start..end]).ok()?.parse().ok()
+}
+
+fn occurrences(haystack: &[u8], needle: &[u8]) -> usize {
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
+}

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -29,7 +29,7 @@ fn resize_child_scenario() {
 }
 
 #[test]
-fn resize_clears_the_reflowed_frame_height() {
+fn resize_resets_a_frame_that_outgrows_the_viewport() {
     let pair = native_pty_system()
         .openpty(PtySize {
             rows: 24,
@@ -95,9 +95,15 @@ fn resize_clears_the_reflowed_frame_height() {
 
     let mut full = Vec::new();
     assert!(
-        !wait_for_frames(&rx, &mut full, 1, Duration::from_millis(500)),
-        "redrew a frame that filled the viewport: {}",
+        wait_for_frames(&rx, &mut full, 1, Duration::from_secs(3)),
+        "did not reset a viewport filled by the frame: {}",
         String::from_utf8_lossy(&full).escape_debug()
+    );
+    let reset = first_frame(&full).unwrap_or(&full);
+    assert!(
+        reset.windows(4).any(|window| window == b"\x1b[2J"),
+        "cramped resize did not clear the visible viewport: {}",
+        String::from_utf8_lossy(reset).escape_debug()
     );
 
     pair.master
@@ -136,11 +142,6 @@ fn resize_clears_the_reflowed_frame_height() {
     reader_thread.join().expect("join reader");
 
     let frame = first_frame(&resized).unwrap_or(&resized);
-    assert!(
-        frame.windows(4).any(|window| window == b"\x1b[0J"),
-        "redraw did not clear downward from the frame anchor: {}",
-        String::from_utf8_lossy(frame).escape_debug()
-    );
     assert_eq!(
         cursor_up_amount(frame),
         Some(1),

--- a/tests/resize.rs
+++ b/tests/resize.rs
@@ -21,7 +21,7 @@ fn resize_child_scenario() {
 
     set_interval(Duration::from_millis(800));
     let job = ProgressJobBuilder::new().body(&"x".repeat(60)).start();
-    thread::sleep(Duration::from_secs(2));
+    thread::sleep(Duration::from_secs(4));
     job.set_status(ProgressStatus::Done);
     clx::progress::stop();
 
@@ -63,6 +63,25 @@ fn resize_clears_the_reflowed_frame_height() {
         "progress display did not render its initial frame"
     );
     while rx.try_recv().is_ok() {}
+
+    // The cursor rests on the row after write_line's trailing newline. A
+    // three-row frame in a three-row viewport has already pushed its first
+    // row into scrollback, so even the equal-height case cannot be cleared.
+    pair.master
+        .resize(PtySize {
+            rows: 3,
+            cols: 20,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .expect("resize pty to exact frame height");
+
+    let mut full = Vec::new();
+    assert!(
+        !wait_for_frames(&rx, &mut full, 1, Duration::from_millis(500)),
+        "redrew a frame that filled the viewport: {}",
+        String::from_utf8_lossy(&full).escape_debug()
+    );
 
     pair.master
         .resize(PtySize {

--- a/tests/synchronized_output.rs
+++ b/tests/synchronized_output.rs
@@ -39,7 +39,12 @@ fn synchronized_output_child_scenario() {
     std::thread::sleep(Duration::from_millis(120));
     child.set_status(ProgressStatus::Done);
     root.set_status(ProgressStatus::Done);
+    // Let the background refresh observe completion and leave its final frame.
+    // Calling stop after that must not append a duplicate frame below it.
+    std::thread::sleep(Duration::from_millis(250));
+    eprintln!("CLX_BEFORE_STOP");
     clx::progress::stop();
+    eprintln!("CLX_AFTER_STOP");
 
     std::process::exit(0);
 }
@@ -75,6 +80,19 @@ fn every_redraw_is_wrapped_in_a_synchronized_update() {
     assert!(
         contains(&bytes, BEGIN),
         "scenario emitted no synchronized-update sequences; the render path did not run"
+    );
+    let after_completion = bytes
+        .split(|byte| *byte == b'\n')
+        .skip_while(|line| !contains(line, b"CLX_BEFORE_STOP"))
+        .skip(1)
+        .take_while(|line| !contains(line, b"CLX_AFTER_STOP"))
+        .flatten()
+        .copied()
+        .collect::<Vec<_>>();
+    assert!(
+        !contains(&after_completion, b"root") && !contains(&after_completion, b"step"),
+        "stop redrew a frame after the background thread had already completed it: {}",
+        String::from_utf8_lossy(&after_completion).escape_debug()
     );
 
     let mut open = false;


### PR DESCRIPTION
## Summary

- redraw stable-size progress updates with the portable cursor-up/clear path
- clear the visible viewport on the first terminal-size change, suppress rendering while dimensions keep moving, and write one fresh layout after 100 ms of stability
- suppress frames that cannot fit in a cramped viewport, then recover with one clean frame when space returns
- avoid a duplicate final redraw when `stop()` runs after background completion
- always restore cursor visibility when stopping an active UI
- keep output caching write-aware
- add PTY coverage, a rapid-resize tmux terminal-state regression, and a 20-second interactive resize demo

## Root cause

Terminal reflow can move part of an existing multi-row progress frame into scrollback before clx observes the new dimensions. Cursor movement and saved-cursor sequences cannot reliably recover that content across terminals; a real-terminal recording also showed CSI save/restore being treated as unsupported, which made ordinary refreshes accumulate.

Clearing and immediately rendering on every reported dimension was still racy during a continuous drag: the terminal could reflow the replacement frame again before dimensions settled. The portable behavior is now explicit:

- stable-size refreshes use cursor-up plus clear-to-end
- the first resize event clears the viewport and leaves it blank
- continued changes restart a 100 ms settle timer
- one final synchronized clear and redraw runs after the size remains stable

This trades visible shell history in the current viewport—and a brief blank progress area while actively dragging—for deterministic recovery without duplicated frames.

## Manual testing

```sh
cargo run --example resize
```

While it runs:

1. Leave the terminal at a stable size and confirm the spinner updates without accumulating rows.
2. Continuously drag the terminal narrower and wider. The viewport should stay blank during active movement, then show exactly one clean layout shortly after you release it.
3. Shrink it until the progress tree cannot fit. It should remain blank until it can show a complete frame.
4. Expand it again and confirm exactly one progress tree appears.
5. Let the demo finish and confirm the cursor is visible below the final output.

An automated real-terminal check is also available when tmux is installed:

```sh
CLX_TMUX_BIN="$(command -v tmux)" cargo test --test resize \
  tmux_resize_keeps_one_copy_of_each_progress_row -- --nocapture
```

The tmux test rapidly changes width in 20 ms increments in both directions, waits for settling, and verifies that each progress row appears exactly once.

## Validation

- `mise run ci`
- `cargo test --test resize -- --nocapture`
- `cargo test --test synchronized_output -- --nocapture`
- rapid tmux resize test from 120 to 40 columns and back

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core TTY redraw, resize, and stop paths for all UI-mode progress; behavior trades brief blank screens during resize for correctness, with good test coverage but terminal-specific edge cases remain possible.
> 
> **Overview**
> Fixes **terminal resize and cramped-viewport** bugs where multi-row progress frames could reflow into scrollback, duplicate rows, or leave a hidden cursor.
> 
> **Resize while jobs are running:** the first size change **clears the viewport** and **defers redraws** until dimensions stay stable for **100ms**, then performs one **full-screen clear** and a single fresh layout. Stable-size updates still use **cursor-up + clear-to-end**.
> 
> **Cramped terminals:** when the rendered frame (or prior frame) would **fill the viewport**, output is **suppressed** until a complete frame fits again, with a one-time clear on entry.
> 
> **Lifecycle fixes:** `LAST_OUTPUT` updates only when a frame is **actually written**; `stop()` avoids a **duplicate final redraw** after the background thread already finished; **`finish_frame()`** restores **cursor visibility** after completion or cramped suppression.
> 
> Adds **`examples/resize`**, **PTY/tmux integration tests**, and unit tests for resize state, height calculation, and deferred caching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ab70879fdf91d007c46f413ebec43642e253e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal resize support for progress displays, including improved redraw behavior across changing terminal sizes.
  * Added a resize progress example demonstrating a long-running, dynamically updating display.

* **Bug Fixes**
  * Prevented duplicate redraws after progress completion.
  * Improved cursor visibility, screen clearing, and output stability during constrained or rapidly changing terminal viewports.

* **Tests**
  * Added coverage for PTY and tmux resizing, terminal reflow, cramped viewports, and synchronized output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->