### PR TITLE
chore(ci): add cargo semver checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
       - uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4
       - run: mise x -- cargo msrv verify
 
+  semver:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2.9
+
   # Aggregator that required-status-checks can target. If any upstream job
   # failed or was skipped, this job fails so branch protection only needs one
   # stable check name.
@@ -51,6 +58,7 @@ jobs:
     needs:
       - ci
       - msrv
+      - semver
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions: {}


### PR DESCRIPTION
## Summary

- add a dedicated cargo-semver-checks job to CI
- compare the current public API against the latest non-yanked clx release on crates.io
- include the semver job in the existing aggregate `final` status check
- pin cargo-semver-checks-action to the v2.9 commit

## Why

Unit tests and clippy do not detect accidental breaking changes to the crate's public API. This makes SemVer compatibility an explicit merge gate.

## Validation

- cargo-semver-checks 0.49.0: 223 checks passed against clx 3.0.0
- actionlint

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or application code; slightly longer PR feedback if semver checks fail.
> 
> **Overview**
> **SemVer is now a merge gate.** A new `semver` job runs `cargo-semver-checks-action` (pinned to v2.9) on Ubuntu and compares the crate’s public API to the latest non-yanked **clx** release on crates.io.
> 
> The existing **`final`** aggregator now depends on `semver` as well as `ci` and `msrv`, so branch protection’s single required check fails if an accidental breaking API change slips through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d7d07456e138f1c771d4fa8260ecb36471e85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->