### PR TITLE
chore: release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/jdx/clx/compare/v3.0.0...v3.0.1) - 2026-07-27
+
+### Fixed
+
+- *(progress)* clear reflowed frame after resize ([#110](https://github.com/jdx/clx/pull/110))
+
 ## [3.0.0](https://github.com/jdx/clx/compare/v2.1.1...v3.0.0) - 2026-07-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clx"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 3.0.0 -> 3.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.1](https://github.com/jdx/clx/compare/v3.0.0...v3.0.1) - 2026-07-27

### Fixed

- *(progress)* clear reflowed frame after resize ([#110](https://github.com/jdx/clx/pull/110))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and version bump only; the behavioral fix ships via the prior PR referenced in the changelog.
> 
> **Overview**
> **Release v3.0.1** bumps the `clx` crate from **3.0.0** to **3.0.1** in `Cargo.toml` and `Cargo.lock`, and documents the release in `CHANGELOG.md`.
> 
> The changelog entry for 3.0.1 records a **progress** fix: clearing a reflowed frame after terminal resize ([#110](https://github.com/jdx/clx/pull/110)). No other source changes are in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e0d4d896b5c3870249eb16b2cf88f1d22498d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->