### PR TITLE
fix(progress): don't write cursor escapes in text or quiet mode

### DIFF
--- a/src/progress/state.rs
+++ b/src/progress/state.rs
@@ -70,8 +70,17 @@ const END_SYNCHRONIZED_UPDATE: &str = "\x1b[?2026l";
 /// outermost guard emits. Mutated only while `TERM_LOCK` is held.
 static SYNC_DEPTH: AtomicUsize = AtomicUsize::new(0);
 
-fn emit_synchronized_updates() -> bool {
+/// Whether progress owns the terminal, i.e. whether cursor and frame escapes
+/// may be written at all. `Text` emits plain lines and `Quiet` emits nothing,
+/// so neither ever renders a frame to move around or a cursor to restore —
+/// writing an escape in those modes corrupts output the caller expects to hold
+/// only its own text.
+pub(crate) fn renders_to_terminal() -> bool {
     !is_disabled() && output() == ProgressOutput::UI
+}
+
+fn emit_synchronized_updates() -> bool {
+    renders_to_terminal()
 }
 
 /// RAII guard that brackets an in-place redraw in a synchronized update so a
@@ -431,14 +440,16 @@ pub fn clear_jobs() {
 pub(crate) fn clear() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    let _guard = TERM_LOCK.lock().unwrap();
-    let _sync = SyncUpdate::begin();
-    if *lines > 0 {
-        term.move_cursor_up(*lines)?;
-        term.move_cursor_left(term.size().1 as usize)?;
-        term.clear_to_end_of_screen()?;
+    if renders_to_terminal() {
+        let _guard = TERM_LOCK.lock().unwrap();
+        let _sync = SyncUpdate::begin();
+        if *lines > 0 {
+            term.move_cursor_up(*lines)?;
+            term.move_cursor_left(term.size().1 as usize)?;
+            term.clear_to_end_of_screen()?;
+        }
+        term.show_cursor()?;
     }
-    term.show_cursor()?;
     *lines = 0;
     CRAMPED_VIEWPORT.store(false, Ordering::Relaxed);
     Ok(())
@@ -448,7 +459,7 @@ pub(crate) fn clear() -> crate::Result<()> {
 pub(crate) fn finish_frame() -> crate::Result<()> {
     let term = term();
     let mut lines = LINES.lock().unwrap();
-    if !is_disabled() && output() == ProgressOutput::UI {
+    if renders_to_terminal() {
         let _guard = TERM_LOCK.lock().unwrap();
         let _sync = SyncUpdate::begin();
         term.show_cursor()?;

--- a/tests/non_ui_output.rs
+++ b/tests/non_ui_output.rs
@@ -1,0 +1,85 @@
+//! Verifies that `Text` and `Quiet` modes never write terminal escapes.
+//!
+//! `stop()`/`stop_clear()` sit on the shutdown path of a CLI regardless of
+//! output mode, so an escape emitted there lands in output the caller expects
+//! to hold only its own text — for a `--quiet` run, to be empty. Escapes go to
+//! the process's real stderr rather than through `eprint!`, so libtest's
+//! capture cannot see them and a child process is the only way to observe what
+//! was actually written.
+
+use std::process::Command;
+
+const SCENARIO_ENV: &str = "CLX_NON_UI_SCENARIO";
+
+/// Child entry point. A no-op during a normal `cargo test` run; the parent
+/// re-invokes it once per output mode and reads back the bytes it wrote.
+#[test]
+fn non_ui_shutdown_child_scenario() {
+    let Some(mode) = std::env::var_os(SCENARIO_ENV) else {
+        return;
+    };
+
+    use clx::progress::{ProgressJobBuilder, ProgressOutput, ProgressStatus, set_output};
+
+    set_output(match mode.to_str() {
+        Some("text") => ProgressOutput::Text,
+        Some("quiet") => ProgressOutput::Quiet,
+        other => panic!("unknown scenario {other:?}"),
+    });
+
+    let job = ProgressJobBuilder::new().prop("message", "working").start();
+    job.prop("message", "still working");
+    job.set_status(ProgressStatus::Done);
+
+    clx::progress::stop_clear();
+    clx::progress::stop();
+
+    std::process::exit(0);
+}
+
+fn child_stderr(mode: &str) -> Vec<u8> {
+    let output = Command::new(std::env::current_exe().expect("current_exe"))
+        .args(["--exact", "non_ui_shutdown_child_scenario", "--nocapture"])
+        .env(SCENARIO_ENV, mode)
+        .output()
+        .expect("spawn child");
+    output.stderr
+}
+
+/// Every escape the progress renderer can emit. Text mode legitimately writes
+/// its own status lines, so the assertion targets the escapes rather than
+/// requiring stderr to be empty.
+const ESCAPES: &[(&str, &[u8])] = &[
+    ("show cursor", b"\x1b[?25h"),
+    ("hide cursor", b"\x1b[?25l"),
+    ("begin synchronized update", b"\x1b[?2026h"),
+    ("end synchronized update", b"\x1b[?2026l"),
+    ("cursor up", b"\x1b[1A"),
+    ("clear to end of screen", b"\x1b[0J"),
+];
+
+fn assert_no_escapes(mode: &str, stderr: &[u8]) {
+    for (name, escape) in ESCAPES {
+        assert!(
+            !stderr.windows(escape.len()).any(|w| w == *escape),
+            "{mode} mode wrote a {name} escape to stderr: {:?}",
+            String::from_utf8_lossy(stderr),
+        );
+    }
+}
+
+#[test]
+fn text_mode_shutdown_writes_no_escapes() {
+    assert_no_escapes("text", &child_stderr("text"));
+}
+
+#[test]
+fn quiet_mode_writes_nothing_at_all() {
+    let stderr = child_stderr("quiet");
+    assert_no_escapes("quiet", &stderr);
+    assert!(
+        stderr.is_empty(),
+        "quiet mode wrote to stderr: {:?}",
+        String::from_utf8_lossy(&stderr),
+    );
+}


### PR DESCRIPTION
## Problem

v3.0.1 added an unconditional `term.show_cursor()` to `clear()` — outside the `lines > 0` guard, and without the output-mode check its sibling `finish_frame()` uses:

```rust
// src/progress/state.rs
if *lines > 0 { /* move up, clear */ }
term.show_cursor()?;   // always writes \x1b[?25h
```

`console::Term::show_cursor()` writes the escape with no TTY check, and `stop_clear()` reaches `clear()` on the shutdown path of every run. So a CLI in `ProgressOutput::Text` or `ProgressOutput::Quiet` now emits `\x1b[?25h` to stderr — into output the caller expects to hold only its own text, or for a `--quiet` run to be empty.

This is a real regression downstream: mise calls `progress::stop_clear()` at the end of every invocation, so `mise use --quiet` started printing `^[[?25h` and broke its e2e suite ([jdx/mise#11358](https://github.com/jdx/mise/pull/11358)).

Minimal reproduction — `set_output(ProgressOutput::Text); stop_clear();`:

| clx | stderr |
|---|---|
| 3.0.0 | *(empty)* |
| 3.0.1 | `^[[?25h` |
| this branch | *(empty)* |

## Fix

Gate the terminal work in `clear()` on the same predicate `finish_frame()` already uses, extracted as `renders_to_terminal()` so the three call sites (`clear`, `finish_frame`, `emit_synchronized_updates`) can't drift apart again.

UI-mode behavior is unchanged. In non-UI modes the background refresh thread never starts, so `LINES` is always 0 and the `lines > 0` branch was already dead; `SyncUpdate` was already gated on the same condition and emitted nothing.

## Test

`tests/non_ui_output.rs` asserts that a full job lifecycle plus `stop_clear()`/`stop()` writes no cursor, synchronized-update, or frame-movement escapes in `Text` mode, and writes nothing at all in `Quiet` mode. Escapes go to the process's real stderr rather than through `eprint!`, so libtest's capture can't see them — the test spawns itself as a child per mode and inspects the raw bytes, following the existing pattern in `tests/synchronized_output.rs`.

Verified it fails on `main` with `text mode wrote a show cursor escape to stderr` and passes here. Full `mise run ci` (clippy, fmt, `cargo test -- --test-threads=1`, progress example) is green; the 3 remaining clippy warnings are pre-existing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavioral fix for non-UI output modes; UI rendering path is unchanged aside from shared predicate extraction.
> 
> **Overview**
> Fixes a regression where **`clear()`** (and thus **`stop_clear()`**) always emitted **`show_cursor`** and other frame escapes on shutdown, even when output is **`Text`** or **`Quiet`**, polluting stderr (e.g. `^[[?25h` on quiet runs).
> 
> Introduces **`renders_to_terminal()`** (UI mode and progress not disabled) and gates **`clear()`**, **`finish_frame()`**, and synchronized-update emission on that single predicate so non-UI modes never write cursor or frame control sequences.
> 
> Adds **`tests/non_ui_output.rs`**, which re-invokes the test binary as a child to assert **Text** shutdown writes no known escapes and **Quiet** writes nothing to stderr.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f45d27d2fe9f1f6e04c265bbc00ce83222bd2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->