### PR TITLE
chore: release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2](https://github.com/jdx/clx/compare/v3.0.1...v3.0.2) - 2026-07-27
+
+### Fixed
+
+- *(progress)* don't write cursor escapes in text or quiet mode ([#113](https://github.com/jdx/clx/pull/113))
+
 ## [3.0.1](https://github.com/jdx/clx/compare/v3.0.0...v3.0.1) - 2026-07-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "clx"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "console",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clx"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 authors = ["jdx"]
 description = "Components for CLI applications"


### PR DESCRIPTION



## 🤖 New release

* `clx`: 3.0.1 -> 3.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.2](https://github.com/jdx/clx/compare/v3.0.1...v3.0.2) - 2026-07-27

### Fixed

- *(progress)* don't write cursor escapes in text or quiet mode ([#113](https://github.com/jdx/clx/pull/113))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog update only; the behavioral fix is already merged in #113.
> 
> **Overview**
> Bumps the **clx** crate from **3.0.1** to **3.0.2** and records the release in **CHANGELOG.md** (dated 2026-07-27). **Cargo.lock** is updated to match the new package version.
> 
> The release note documents a **progress** fix ([#113](https://github.com/jdx/clx/pull/113)): cursor escape sequences are no longer emitted when output is in **text** or **quiet** mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33150168e7ed821a5ef0fd52e17511925b48eb96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->